### PR TITLE
chore(alert-dialog): fix a11y keyboard issue for AlertDialog

### DIFF
--- a/packages/primitives/alert-dialog/src/alert-dialog-content.directive.ts
+++ b/packages/primitives/alert-dialog/src/alert-dialog-content.directive.ts
@@ -1,10 +1,17 @@
+import { CdkTrapFocus } from '@angular/cdk/a11y';
 import { Directive, ElementRef, inject, Input, Renderer2 } from '@angular/core';
 
 @Directive({
     selector: '[rdxAlertDialogContent]',
+    hostDirectives: [
+        {
+            directive: CdkTrapFocus
+        }
+    ],
     standalone: true,
     host: {
-        '[attr.data-state]': 'open'
+        '[attr.data-state]': 'open',
+        '[attr.cdkTrapFocusAutoCapture]': 'true'
     }
 })
 export class AlertDialogContentDirective {

--- a/packages/primitives/alert-dialog/src/alert-dialog.service.ts
+++ b/packages/primitives/alert-dialog/src/alert-dialog.service.ts
@@ -41,6 +41,12 @@ export class AlertDialogService {
         );
         this.overlayRef.attach(templatePortal);
 
+        this.overlayRef.keydownEvents().subscribe((event) => {
+            console.log(event.key, event.code);
+            if (event.key === 'Escape' || event.code === 'Escape') {
+                this.close();
+            }
+        });
         this.overlayRef.backdropClick().subscribe(() => this.close());
     }
 

--- a/packages/primitives/alert-dialog/src/alert-dialog.service.ts
+++ b/packages/primitives/alert-dialog/src/alert-dialog.service.ts
@@ -42,7 +42,6 @@ export class AlertDialogService {
         this.overlayRef.attach(templatePortal);
 
         this.overlayRef.keydownEvents().subscribe((event) => {
-            console.log(event.key, event.code);
             if (event.key === 'Escape' || event.code === 'Escape') {
                 this.close();
             }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description
Fix a11y keyboard issue for AlertDialog,
1. TAB should remain dialog
2. input 'Escape' key should exit dialog.
<!-- Describe the change you are introducing -->
