### PR TITLE
feat(popover): add animation on open and close

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,5 @@ ng-doc
 
 # eslint ignores root level "dot" files by default
 !/.*.cjs
+
+!global.d.ts

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/.prettierignore
+++ b/.prettierignore
@@ -20,3 +20,4 @@ apps/shadcn-docs/src/styles/themes/*.css
 pnpm-lock.yaml
 pnpm-workspace.yaml
 
+!global.d.ts

--- a/apps/storybook-radix/.storybook/tsconfig.json
+++ b/apps/storybook-radix/.storybook/tsconfig.json
@@ -12,6 +12,7 @@
         "../../../packages/primitives/**/*.directive.ts",
         "../../../packages/primitives/**/*.component.ts",
         "*.ts",
-        "*.tsx"
+        "*.tsx",
+        "../global.d.ts"
     ]
 }

--- a/apps/storybook-radix/global.d.ts
+++ b/apps/storybook-radix/global.d.ts
@@ -1,0 +1,1 @@
+import '../../global';

--- a/apps/storybook-radix/tsconfig.json
+++ b/apps/storybook-radix/tsconfig.json
@@ -8,7 +8,9 @@
         "noImplicitOverride": true,
         "noPropertyAccessFromIndexSignature": true,
         "noImplicitReturns": true,
-        "noFallthroughCasesInSwitch": true
+        "noFallthroughCasesInSwitch": true,
+        "types": ["node", "global"],
+        "typeRoots": ["../../node_modules/@types", "./"]
     },
     "files": [],
     "include": [],

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,7 @@
+interface MouseEvent {
+    defaultPreventedCustom?: boolean;
+}
+
+interface KeyboardEvent {
+    defaultPreventedCustom?: boolean;
+}

--- a/packages/primitives/core/src/create-inject-context/index.ts
+++ b/packages/primitives/core/src/create-inject-context/index.ts
@@ -178,7 +178,7 @@ createInjectionToken is creating a root InjectionToken but an external token is 
                     return factory(
                         ...opts.deps.map((dep) => {
                             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                            // @ts-expect-error
+                            // @ts-ignore
                             dep = (Array.isArray(dep) ? dep.at(-1) : dep) as CreateInjectionTokenDep<any>;
                             return inject(dep);
                         })

--- a/packages/primitives/global.d.ts
+++ b/packages/primitives/global.d.ts
@@ -1,0 +1,1 @@
+import './../../global';

--- a/packages/primitives/popover/index.ts
+++ b/packages/primitives/popover/index.ts
@@ -1,12 +1,14 @@
 import { NgModule } from '@angular/core';
 import { RdxPopoverArrowDirective } from './src/popover-arrow.directive';
 import { RdxPopoverCloseDirective } from './src/popover-close.directive';
+import { RdxPopoverContentAttributesComponent } from './src/popover-content-attributes.component';
 import { RdxPopoverContentDirective } from './src/popover-content.directive';
 import { RdxPopoverRootDirective } from './src/popover-root.directive';
 import { RdxPopoverTriggerDirective } from './src/popover-trigger.directive';
 
 export * from './src/popover-arrow.directive';
 export * from './src/popover-close.directive';
+export * from './src/popover-content-attributes.component';
 export * from './src/popover-content.directive';
 export * from './src/popover-root.directive';
 export * from './src/popover-trigger.directive';
@@ -17,7 +19,8 @@ const _imports = [
     RdxPopoverCloseDirective,
     RdxPopoverContentDirective,
     RdxPopoverTriggerDirective,
-    RdxPopoverRootDirective
+    RdxPopoverRootDirective,
+    RdxPopoverContentAttributesComponent
 ];
 
 @NgModule({

--- a/packages/primitives/popover/src/popover-arrow.directive.ts
+++ b/packages/primitives/popover/src/popover-arrow.directive.ts
@@ -36,12 +36,14 @@ export class RdxPopoverArrowDirective implements AfterViewInit {
     private readonly elementRef = inject(ElementRef);
 
     /**
-     * The width of the arrow in pixels.
+     * @description The width of the arrow in pixels.
+     * @default 10
      */
     readonly width = input<number>(10);
 
     /**
-     * The height of the arrow in pixels.
+     * @description The height of the arrow in pixels.
+     * @default 5
      */
     readonly height = input<number>(5);
 

--- a/packages/primitives/popover/src/popover-arrow.directive.ts
+++ b/packages/primitives/popover/src/popover-arrow.directive.ts
@@ -95,9 +95,9 @@ export class RdxPopoverArrowDirective implements AfterViewInit {
         );
 
         this.renderer.setStyle(this.elementRef.nativeElement, 'top', posParams.top);
-        this.renderer.setStyle(this.elementRef.nativeElement, 'bottom', posParams.bottom);
+        this.renderer.setStyle(this.elementRef.nativeElement, 'bottom', '');
         this.renderer.setStyle(this.elementRef.nativeElement, 'left', posParams.left);
-        this.renderer.setStyle(this.elementRef.nativeElement, 'right', posParams.right);
+        this.renderer.setStyle(this.elementRef.nativeElement, 'right', '');
         this.renderer.setStyle(this.elementRef.nativeElement, 'transform', posParams.transform);
     }
 

--- a/packages/primitives/popover/src/popover-close.directive.ts
+++ b/packages/primitives/popover/src/popover-close.directive.ts
@@ -11,9 +11,9 @@ import { injectPopoverRoot } from './popover-root.inject';
 })
 export class RdxPopoverCloseDirective {
     /** @ignore */
-    readonly popoverRoot = injectPopoverRoot();
+    protected readonly popoverRoot = injectPopoverRoot();
     /** @ignore */
-    readonly elementRef = inject(ElementRef);
+    private readonly elementRef = inject(ElementRef);
     /** @ignore */
     private readonly renderer = inject(Renderer2);
 

--- a/packages/primitives/popover/src/popover-content-attributes.component.ts
+++ b/packages/primitives/popover/src/popover-content-attributes.component.ts
@@ -2,7 +2,6 @@ import { Component, computed, forwardRef } from '@angular/core';
 import { RdxPopoverContentAttributesToken } from './popover-content-attributes.token';
 import { injectPopoverRoot } from './popover-root.inject';
 import { RdxPopoverAnimationStatus, RdxPopoverState } from './popover.types';
-import { isRdxPopoverDevMode } from './popover.utils';
 
 @Component({
     selector: '[rdxPopoverContentAttributes]',
@@ -38,13 +37,6 @@ export class RdxPopoverContentAttributesComponent {
 
     /** @ignore */
     protected onAnimationStart(_: AnimationEvent) {
-        isRdxPopoverDevMode() &&
-            console.log(
-                this.popoverRoot.uniqueId(),
-                '[onAnimationStart]',
-                this.popoverRoot.state(),
-                this.popoverRoot.getAnimationParamsSnapshot()
-            );
         this.popoverRoot.cssAnimationStatus.set(
             this.popoverRoot.state() === RdxPopoverState.OPEN
                 ? RdxPopoverAnimationStatus.OPEN_STARTED
@@ -54,13 +46,6 @@ export class RdxPopoverContentAttributesComponent {
 
     /** @ignore */
     protected onAnimationEnd(_: AnimationEvent) {
-        isRdxPopoverDevMode() &&
-            console.log(
-                this.popoverRoot.uniqueId(),
-                '[onAnimationEnd]',
-                this.popoverRoot.state(),
-                this.popoverRoot.getAnimationParamsSnapshot()
-            );
         this.popoverRoot.cssAnimationStatus.set(
             this.popoverRoot.state() === RdxPopoverState.OPEN
                 ? RdxPopoverAnimationStatus.OPEN_ENDED
@@ -72,8 +57,8 @@ export class RdxPopoverContentAttributesComponent {
     private canAnimate() {
         return (
             this.popoverRoot.cssAnimation() &&
-            ((this.popoverRoot.cssOpenAnimation() && this.popoverRoot.state() === RdxPopoverState.OPEN) ||
-                (this.popoverRoot.cssCloseAnimation() && this.popoverRoot.state() === RdxPopoverState.CLOSED))
+            ((this.popoverRoot.cssOpeningAnimation() && this.popoverRoot.state() === RdxPopoverState.OPEN) ||
+                (this.popoverRoot.cssClosingAnimation() && this.popoverRoot.state() === RdxPopoverState.CLOSED))
         );
     }
 }

--- a/packages/primitives/popover/src/popover-content-attributes.component.ts
+++ b/packages/primitives/popover/src/popover-content-attributes.component.ts
@@ -10,154 +10,11 @@ import { isRdxPopoverDevMode } from './popover.utils';
     template: `
         <ng-content />
     `,
-    styles: `
-        :host {
-            &.rdx-animated-content {
-                &:is(.rdx-animated-content-open, .rdx-animated-content-close) {
-                    animation-duration: 400ms;
-                    animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-                    will-change: transform, opacity;
-                }
-
-                &.rdx-animated-content-open {
-                    &[data-state='open'][data-side='top'] {
-                        animation-name: rdxSlideDownAndFade;
-                    }
-
-                    &[data-state='open'][data-side='right'] {
-                        animation-name: rdxSlideLeftAndFade;
-                    }
-
-                    &[data-state='open'][data-side='bottom'] {
-                        animation-name: rdxSlideUpAndFade;
-                    }
-
-                    &[data-state='open'][data-side='left'] {
-                        animation-name: rdxSlideRightAndFade;
-                    }
-                }
-
-                &.rdx-animated-content-close {
-                    &[data-state='closed'][data-side='top'] {
-                        animation-name: rdxSlideDownAndFadeReverse;
-                    }
-
-                    &[data-state='closed'][data-side='right'] {
-                        animation-name: rdxSlideLeftAndFadeReverse;
-                    }
-
-                    &[data-state='closed'][data-side='bottom'] {
-                        animation-name: rdxSlideUpAndFadeReverse;
-                    }
-
-                    &[data-state='closed'][data-side='left'] {
-                        animation-name: rdxSlideRightAndFadeReverse;
-                    }
-                }
-            }
-        }
-
-        /* Open animations */
-
-        @keyframes rdxSlideUpAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(2px);
-                /*transition:left 1s linear;*/
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes rdxSlideRightAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        @keyframes rdxSlideDownAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes rdxSlideLeftAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        /* Close animations */
-
-        @keyframes rdxSlideUpAndFadeReverse {
-            from {
-                opacity: 1;
-                transform: translateY(0);
-            }
-            to {
-                opacity: 0;
-                transform: translateY(2px);
-            }
-        }
-
-        @keyframes rdxSlideRightAndFadeReverse {
-            from {
-                opacity: 1;
-                transform: translateX(0);
-            }
-            to {
-                opacity: 0;
-                transform: translateX(-2px);
-            }
-        }
-
-        @keyframes rdxSlideDownAndFadeReverse {
-            from {
-                opacity: 1;
-                transform: translateY(0);
-            }
-            to {
-                opacity: 0;
-                transform: translateY(-2px);
-            }
-        }
-
-        @keyframes rdxSlideLeftAndFadeReverse {
-            from {
-                opacity: 1;
-                transform: translateX(0);
-            }
-            to {
-                opacity: 0;
-                transform: translateX(2px);
-            }
-        }
-    `,
     host: {
         '[attr.id]': 'name()',
         '[attr.data-state]': 'popoverRoot.state()',
         '[attr.data-side]': 'popoverRoot.popoverContentDirective().side()',
-        '[class.rdx-animated-content]': 'popoverRoot.cssAnimation() === true',
-        '[class.rdx-animated-content-open]': 'popoverRoot.cssAnimation() === true && popoverRoot.cssOnShowAnimation()',
-        '[class.rdx-animated-content-close]':
-            'popoverRoot.cssAnimation() === true && popoverRoot.cssOnCloseAnimation()',
+        '[style]': 'disableAnimation() ? {animation: "none !important"} : null',
         '(animationstart)': 'onAnimationStart($event)',
         '(animationend)': 'onAnimationEnd($event)'
     },
@@ -174,6 +31,8 @@ export class RdxPopoverContentAttributesComponent {
 
     /** @ignore */
     readonly name = computed(() => `rdx-popover-content-attributes-${this.popoverRoot.uniqueId()}`);
+
+    readonly disableAnimation = computed(() => !this.canAnimate());
 
     /** @ignore */
     protected onAnimationStart(_: AnimationEvent) {
@@ -193,6 +52,14 @@ export class RdxPopoverContentAttributesComponent {
             this.popoverRoot.state() === RdxPopoverState.OPEN
                 ? RdxPopoverAnimationStatus.OPEN_ENDED
                 : RdxPopoverAnimationStatus.CLOSED_ENDED
+        );
+    }
+
+    private canAnimate() {
+        return (
+            this.popoverRoot.cssAnimation() &&
+            ((this.popoverRoot.cssOnShowAnimation() && this.popoverRoot.state() === RdxPopoverState.OPEN) ||
+                (this.popoverRoot.cssOnCloseAnimation() && this.popoverRoot.state() === RdxPopoverState.CLOSED))
         );
     }
 }

--- a/packages/primitives/popover/src/popover-content-attributes.component.ts
+++ b/packages/primitives/popover/src/popover-content-attributes.component.ts
@@ -1,0 +1,198 @@
+import { Component, computed, forwardRef } from '@angular/core';
+import { RdxPopoverContentAttributesToken } from './popover-content-attributes.token';
+import { injectPopoverRoot } from './popover-root.inject';
+import { RdxPopoverAnimationStatus, RdxPopoverState } from './popover.types';
+import { isRdxPopoverDevMode } from './popover.utils';
+
+@Component({
+    selector: '[rdxPopoverContentAttributes]',
+    standalone: true,
+    template: `
+        <ng-content />
+    `,
+    styles: `
+        :host {
+            &.rdx-animated-content {
+                &:is(.rdx-animated-content-open, .rdx-animated-content-close) {
+                    animation-duration: 400ms;
+                    animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+                    will-change: transform, opacity;
+                }
+
+                &.rdx-animated-content-open {
+                    &[data-state='open'][data-side='top'] {
+                        animation-name: rdxSlideDownAndFade;
+                    }
+
+                    &[data-state='open'][data-side='right'] {
+                        animation-name: rdxSlideLeftAndFade;
+                    }
+
+                    &[data-state='open'][data-side='bottom'] {
+                        animation-name: rdxSlideUpAndFade;
+                    }
+
+                    &[data-state='open'][data-side='left'] {
+                        animation-name: rdxSlideRightAndFade;
+                    }
+                }
+
+                &.rdx-animated-content-close {
+                    &[data-state='closed'][data-side='top'] {
+                        animation-name: rdxSlideDownAndFadeReverse;
+                    }
+
+                    &[data-state='closed'][data-side='right'] {
+                        animation-name: rdxSlideLeftAndFadeReverse;
+                    }
+
+                    &[data-state='closed'][data-side='bottom'] {
+                        animation-name: rdxSlideUpAndFadeReverse;
+                    }
+
+                    &[data-state='closed'][data-side='left'] {
+                        animation-name: rdxSlideRightAndFadeReverse;
+                    }
+                }
+            }
+        }
+
+        /* Open animations */
+
+        @keyframes rdxSlideUpAndFade {
+            from {
+                opacity: 0;
+                transform: translateY(2px);
+                /*transition:left 1s linear;*/
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        @keyframes rdxSlideRightAndFade {
+            from {
+                opacity: 0;
+                transform: translateX(-2px);
+            }
+            to {
+                opacity: 1;
+                transform: translateX(0);
+            }
+        }
+
+        @keyframes rdxSlideDownAndFade {
+            from {
+                opacity: 0;
+                transform: translateY(-2px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        @keyframes rdxSlideLeftAndFade {
+            from {
+                opacity: 0;
+                transform: translateX(2px);
+            }
+            to {
+                opacity: 1;
+                transform: translateX(0);
+            }
+        }
+
+        /* Close animations */
+
+        @keyframes rdxSlideUpAndFadeReverse {
+            from {
+                opacity: 1;
+                transform: translateY(0);
+            }
+            to {
+                opacity: 0;
+                transform: translateY(2px);
+            }
+        }
+
+        @keyframes rdxSlideRightAndFadeReverse {
+            from {
+                opacity: 1;
+                transform: translateX(0);
+            }
+            to {
+                opacity: 0;
+                transform: translateX(-2px);
+            }
+        }
+
+        @keyframes rdxSlideDownAndFadeReverse {
+            from {
+                opacity: 1;
+                transform: translateY(0);
+            }
+            to {
+                opacity: 0;
+                transform: translateY(-2px);
+            }
+        }
+
+        @keyframes rdxSlideLeftAndFadeReverse {
+            from {
+                opacity: 1;
+                transform: translateX(0);
+            }
+            to {
+                opacity: 0;
+                transform: translateX(2px);
+            }
+        }
+    `,
+    host: {
+        '[attr.id]': 'name()',
+        '[attr.data-state]': 'popoverRoot.state()',
+        '[attr.data-side]': 'popoverRoot.popoverContentDirective().side()',
+        '[class.rdx-animated-content]': 'popoverRoot.cssAnimation() === true',
+        '[class.rdx-animated-content-open]': 'popoverRoot.cssAnimation() === true && popoverRoot.cssOnShowAnimation()',
+        '[class.rdx-animated-content-close]':
+            'popoverRoot.cssAnimation() === true && popoverRoot.cssOnCloseAnimation()',
+        '(animationstart)': 'onAnimationStart($event)',
+        '(animationend)': 'onAnimationEnd($event)'
+    },
+    providers: [
+        {
+            provide: RdxPopoverContentAttributesToken,
+            useExisting: forwardRef(() => RdxPopoverContentAttributesComponent)
+        }
+    ]
+})
+export class RdxPopoverContentAttributesComponent {
+    /** @ignore */
+    protected readonly popoverRoot = injectPopoverRoot();
+
+    /** @ignore */
+    readonly name = computed(() => `rdx-popover-content-attributes-${this.popoverRoot.uniqueId()}`);
+
+    /** @ignore */
+    protected onAnimationStart(_: AnimationEvent) {
+        isRdxPopoverDevMode() &&
+            console.log(this.popoverRoot.uniqueId(), '[onAnimationStart]', this.popoverRoot.state());
+        this.popoverRoot.cssAnimationStatus.set(
+            this.popoverRoot.state() === RdxPopoverState.OPEN
+                ? RdxPopoverAnimationStatus.OPEN_STARTED
+                : RdxPopoverAnimationStatus.CLOSED_STARTED
+        );
+    }
+
+    /** @ignore */
+    protected onAnimationEnd(_: AnimationEvent) {
+        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[onAnimationEnd]', this.popoverRoot.state());
+        this.popoverRoot.cssAnimationStatus.set(
+            this.popoverRoot.state() === RdxPopoverState.OPEN
+                ? RdxPopoverAnimationStatus.OPEN_ENDED
+                : RdxPopoverAnimationStatus.CLOSED_ENDED
+        );
+    }
+}

--- a/packages/primitives/popover/src/popover-content-attributes.component.ts
+++ b/packages/primitives/popover/src/popover-content-attributes.component.ts
@@ -14,6 +14,7 @@ import { isRdxPopoverDevMode } from './popover.utils';
         '[attr.id]': 'name()',
         '[attr.data-state]': 'popoverRoot.state()',
         '[attr.data-side]': 'popoverRoot.popoverContentDirective().side()',
+        '[attr.data-align]': 'popoverRoot.popoverContentDirective().align()',
         '[style]': 'disableAnimation() ? {animation: "none !important"} : null',
         '(animationstart)': 'onAnimationStart($event)',
         '(animationend)': 'onAnimationEnd($event)'
@@ -32,12 +33,18 @@ export class RdxPopoverContentAttributesComponent {
     /** @ignore */
     readonly name = computed(() => `rdx-popover-content-attributes-${this.popoverRoot.uniqueId()}`);
 
+    /** @ignore */
     readonly disableAnimation = computed(() => !this.canAnimate());
 
     /** @ignore */
     protected onAnimationStart(_: AnimationEvent) {
         isRdxPopoverDevMode() &&
-            console.log(this.popoverRoot.uniqueId(), '[onAnimationStart]', this.popoverRoot.state());
+            console.log(
+                this.popoverRoot.uniqueId(),
+                '[onAnimationStart]',
+                this.popoverRoot.state(),
+                this.popoverRoot.getAnimationParamsSnapshot()
+            );
         this.popoverRoot.cssAnimationStatus.set(
             this.popoverRoot.state() === RdxPopoverState.OPEN
                 ? RdxPopoverAnimationStatus.OPEN_STARTED
@@ -47,7 +54,13 @@ export class RdxPopoverContentAttributesComponent {
 
     /** @ignore */
     protected onAnimationEnd(_: AnimationEvent) {
-        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[onAnimationEnd]', this.popoverRoot.state());
+        isRdxPopoverDevMode() &&
+            console.log(
+                this.popoverRoot.uniqueId(),
+                '[onAnimationEnd]',
+                this.popoverRoot.state(),
+                this.popoverRoot.getAnimationParamsSnapshot()
+            );
         this.popoverRoot.cssAnimationStatus.set(
             this.popoverRoot.state() === RdxPopoverState.OPEN
                 ? RdxPopoverAnimationStatus.OPEN_ENDED
@@ -55,11 +68,12 @@ export class RdxPopoverContentAttributesComponent {
         );
     }
 
+    /** @ignore */
     private canAnimate() {
         return (
             this.popoverRoot.cssAnimation() &&
-            ((this.popoverRoot.cssOnShowAnimation() && this.popoverRoot.state() === RdxPopoverState.OPEN) ||
-                (this.popoverRoot.cssOnCloseAnimation() && this.popoverRoot.state() === RdxPopoverState.CLOSED))
+            ((this.popoverRoot.cssOpenAnimation() && this.popoverRoot.state() === RdxPopoverState.OPEN) ||
+                (this.popoverRoot.cssCloseAnimation() && this.popoverRoot.state() === RdxPopoverState.CLOSED))
         );
     }
 }

--- a/packages/primitives/popover/src/popover-content-attributes.token.ts
+++ b/packages/primitives/popover/src/popover-content-attributes.token.ts
@@ -1,0 +1,6 @@
+import { InjectionToken } from '@angular/core';
+import { RdxPopoverContentAttributesComponent } from './popover-content-attributes.component';
+
+export const RdxPopoverContentAttributesToken = new InjectionToken<RdxPopoverContentAttributesComponent>(
+    'RdxPopoverContentAttributesToken'
+);

--- a/packages/primitives/popover/src/popover-content.directive.ts
+++ b/packages/primitives/popover/src/popover-content.directive.ts
@@ -17,7 +17,7 @@ import { filter, tap } from 'rxjs';
 import { injectPopoverRoot } from './popover-root.inject';
 import { DEFAULTS } from './popover.constants';
 import { RdxPopoverAlign, RdxPopoverAttachDetachEvent, RdxPopoverSide, RdxSideAndAlignOffsets } from './popover.types';
-import { getAllPossibleConnectedPositions, getContentPosition, isRdxPopoverDevMode } from './popover.utils';
+import { getAllPossibleConnectedPositions, getContentPosition } from './popover.utils';
 
 @Directive({
     selector: '[rdxPopoverContent]',
@@ -174,14 +174,8 @@ export class RdxPopoverContentDirective implements OnInit {
             .asObservable()
             .pipe(
                 tap(() => {
-                    isRdxPopoverDevMode() &&
-                        console.log(
-                            this.popoverRoot.uniqueId(),
-                            '[content attach]',
-                            this.popoverRoot.getAnimationParamsSnapshot()
-                        );
                     /**
-                     * `this.onOpen.emit();` is being delegated to the root directive due to the open animation
+                     * `this.onOpen.emit();` is being delegated to the root directive due to the opening animation
                      */
                     this.popoverRoot.attachDetachEvent.set(RdxPopoverAttachDetachEvent.ATTACH);
                 }),
@@ -196,14 +190,8 @@ export class RdxPopoverContentDirective implements OnInit {
             .asObservable()
             .pipe(
                 tap(() => {
-                    isRdxPopoverDevMode() &&
-                        console.log(
-                            this.popoverRoot.uniqueId(),
-                            '[content detach]',
-                            this.popoverRoot.getAnimationParamsSnapshot()
-                        );
                     /**
-                     * `this.onClosed.emit();` is being delegated to the root directive due to the open animation
+                     * `this.onClosed.emit();` is being delegated to the root directive due to the closing animation
                      */
                     this.popoverRoot.attachDetachEvent.set(RdxPopoverAttachDetachEvent.DETACH);
                 }),
@@ -235,18 +223,6 @@ export class RdxPopoverContentDirective implements OnInit {
 
     /** @ignore */
     private computePositions() {
-        isRdxPopoverDevMode() &&
-            console.log(
-                this.popoverRoot.uniqueId(),
-                '[inputs]',
-                {
-                    side: this.side(),
-                    align: this.align(),
-                    sideOffset: this.sideOffset(),
-                    alignOffset: this.alignOffset()
-                },
-                this.popoverRoot.getAnimationParamsSnapshot()
-            );
         const greatestDimensionFromTheArrow = Math.max(
             this.popoverRoot.popoverArrowDirective()?.width() ?? 0,
             this.popoverRoot.popoverArrowDirective()?.height() ?? 0
@@ -255,21 +231,12 @@ export class RdxPopoverContentDirective implements OnInit {
             sideOffset: this.sideOffset() ?? (greatestDimensionFromTheArrow || DEFAULTS.offsets.side),
             alignOffset: this.alignOffset() ?? DEFAULTS.offsets.align
         };
-        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[offsets]', offsets);
-        isRdxPopoverDevMode() &&
-            console.log(this.popoverRoot.uniqueId(), '[computed inputs]', {
-                side: this.side(),
-                align: this.align(),
-                sideOffset: offsets.sideOffset,
-                alignOffset: offsets.alignOffset
-            });
         const basePosition = getContentPosition({
             side: this.side(),
             align: this.align(),
             sideOffset: offsets.sideOffset,
             alignOffset: offsets.alignOffset
         });
-        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[basePosition]', basePosition);
         const positions = [basePosition];
         if (!this.disableAlternatePositions()) {
             /**
@@ -293,7 +260,6 @@ export class RdxPopoverContentDirective implements OnInit {
                 }
             });
         }
-        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[positions]', positions);
         return positions;
     }
 

--- a/packages/primitives/popover/src/popover-content.directive.ts
+++ b/packages/primitives/popover/src/popover-content.directive.ts
@@ -62,63 +62,7 @@ export class RdxPopoverContentDirective implements OnInit {
     readonly disableAlternatePositions = input(false);
 
     /** @ingore */
-    readonly positions = computed(() => {
-        isRdxPopoverDevMode() &&
-            console.log(this.popoverRoot.uniqueId(), '[inputs]', {
-                side: this.side(),
-                align: this.align(),
-                sideOffset: this.sideOffset(),
-                alignOffset: this.alignOffset()
-            });
-        const greatestDimensionFromTheArrow = Math.max(
-            this.popoverRoot.popoverArrowDirective()?.width() ?? 0,
-            this.popoverRoot.popoverArrowDirective()?.height() ?? 0
-        );
-        const offsets: RdxSideAndAlignOffsets = {
-            sideOffset: this.sideOffset() ?? (greatestDimensionFromTheArrow || DEFAULTS.offsets.side),
-            alignOffset: this.alignOffset() ?? DEFAULTS.offsets.align
-        };
-        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[offsets]', offsets);
-        isRdxPopoverDevMode() &&
-            console.log(this.popoverRoot.uniqueId(), '[computed inputs]', {
-                side: this.side(),
-                align: this.align(),
-                sideOffset: offsets.sideOffset,
-                alignOffset: offsets.alignOffset
-            });
-        const basePosition = getContentPosition({
-            side: this.side(),
-            align: this.align(),
-            sideOffset: offsets.sideOffset,
-            alignOffset: offsets.alignOffset
-        });
-        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[basePosition]', basePosition);
-        const positions = [basePosition];
-        if (!this.disableAlternatePositions()) {
-            /**
-             * Alternate positions for better user experience along the X/Y axis (e.g. vertical/horizontal scrolling)
-             */
-            const allPossibleConnectedPositions = getAllPossibleConnectedPositions();
-            allPossibleConnectedPositions.forEach((_, key) => {
-                const sideAndAlignArray = key.split('|');
-                if (
-                    (sideAndAlignArray[0] as RdxPopoverSide) !== this.side() ||
-                    (sideAndAlignArray[1] as RdxPopoverAlign) !== this.align()
-                ) {
-                    positions.push(
-                        getContentPosition({
-                            side: sideAndAlignArray[0] as RdxPopoverSide,
-                            align: sideAndAlignArray[1] as RdxPopoverAlign,
-                            sideOffset: offsets.sideOffset,
-                            alignOffset: offsets.alignOffset
-                        })
-                    );
-                }
-            });
-        }
-        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[positions]', positions);
-        return positions;
-    });
+    readonly positions = computed(() => this.computePositions());
 
     /**
      * Event handler called when the escape key is down. It can be prevented by calling event.preventDefault.
@@ -131,7 +75,7 @@ export class RdxPopoverContentDirective implements OnInit {
     readonly onPointerDownOutside = output<MouseEvent>();
 
     /**
-     * Event handler called when the overlay is atached
+     * Event handler called when the overlay is attached
      */
     readonly onShow = output<void>();
     /**
@@ -263,6 +207,65 @@ export class RdxPopoverContentDirective implements OnInit {
         this.connectedOverlay.ngOnChanges({
             origin: new SimpleChange(prevOrigin, this.connectedOverlay.origin, false)
         });
+    }
+
+    /** @ignore */
+    private computePositions() {
+        isRdxPopoverDevMode() &&
+            console.log(this.popoverRoot.uniqueId(), '[inputs]', {
+                side: this.side(),
+                align: this.align(),
+                sideOffset: this.sideOffset(),
+                alignOffset: this.alignOffset()
+            });
+        const greatestDimensionFromTheArrow = Math.max(
+            this.popoverRoot.popoverArrowDirective()?.width() ?? 0,
+            this.popoverRoot.popoverArrowDirective()?.height() ?? 0
+        );
+        const offsets: RdxSideAndAlignOffsets = {
+            sideOffset: this.sideOffset() ?? (greatestDimensionFromTheArrow || DEFAULTS.offsets.side),
+            alignOffset: this.alignOffset() ?? DEFAULTS.offsets.align
+        };
+        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[offsets]', offsets);
+        isRdxPopoverDevMode() &&
+            console.log(this.popoverRoot.uniqueId(), '[computed inputs]', {
+                side: this.side(),
+                align: this.align(),
+                sideOffset: offsets.sideOffset,
+                alignOffset: offsets.alignOffset
+            });
+        const basePosition = getContentPosition({
+            side: this.side(),
+            align: this.align(),
+            sideOffset: offsets.sideOffset,
+            alignOffset: offsets.alignOffset
+        });
+        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[basePosition]', basePosition);
+        const positions = [basePosition];
+        if (!this.disableAlternatePositions()) {
+            /**
+             * Alternate positions for better user experience along the X/Y axis (e.g. vertical/horizontal scrolling)
+             */
+            const allPossibleConnectedPositions = getAllPossibleConnectedPositions();
+            allPossibleConnectedPositions.forEach((_, key) => {
+                const sideAndAlignArray = key.split('|');
+                if (
+                    (sideAndAlignArray[0] as RdxPopoverSide) !== this.side() ||
+                    (sideAndAlignArray[1] as RdxPopoverAlign) !== this.align()
+                ) {
+                    positions.push(
+                        getContentPosition({
+                            side: sideAndAlignArray[0] as RdxPopoverSide,
+                            align: sideAndAlignArray[1] as RdxPopoverAlign,
+                            sideOffset: offsets.sideOffset,
+                            alignOffset: offsets.alignOffset
+                        })
+                    );
+                }
+            });
+        }
+        isRdxPopoverDevMode() && console.log(this.popoverRoot.uniqueId(), '[positions]', positions);
+        return positions;
     }
 
     /** @ignore */

--- a/packages/primitives/popover/src/popover-root.directive.ts
+++ b/packages/primitives/popover/src/popover-root.directive.ts
@@ -21,7 +21,6 @@ import { RdxPopoverContentDirective } from './popover-content.directive';
 import { RdxPopoverRootToken } from './popover-root.token';
 import { RdxPopoverTriggerDirective } from './popover-trigger.directive';
 import { RdxPopoverAnimationStatus, RdxPopoverAttachDetachEvent, RdxPopoverState } from './popover.types';
-import { isRdxPopoverDevMode } from './popover.utils';
 
 let nextId = 0;
 
@@ -58,20 +57,20 @@ export class RdxPopoverRootDirective {
      */
     readonly externalControl = input<boolean | undefined>(void 0);
     /**
-     * @description Whether to take into account CSS open/close animations.
+     * @description Whether to take into account CSS opening/closing animations.
      * @default false
      */
     readonly cssAnimation = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
     /**
-     * @description Whether to take into account CSS open animations. `cssAnimation` input must be set to 'true'
+     * @description Whether to take into account CSS opening animations. `cssAnimation` input must be set to 'true'
      * @default false
      */
-    readonly cssOpenAnimation = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
+    readonly cssOpeningAnimation = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
     /**
-     * @description Whether to take into account CSS close animations. `cssAnimation` input must be set to 'true'
+     * @description Whether to take into account CSS closing animations. `cssAnimation` input must be set to 'true'
      * @default false
      */
-    readonly cssCloseAnimation = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
+    readonly cssClosingAnimation = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
     /** @ignore */
     readonly cssAnimationStatus = signal<RdxPopoverAnimationStatus | null>(null);
@@ -120,8 +119,8 @@ export class RdxPopoverRootDirective {
     getAnimationParamsSnapshot() {
         return {
             cssAnimation: this.cssAnimation(),
-            cssOpenAnimation: this.cssOpenAnimation(),
-            cssCloseAnimation: this.cssCloseAnimation(),
+            cssOpeningAnimation: this.cssOpeningAnimation(),
+            cssClosingAnimation: this.cssClosingAnimation(),
             cssAnimationStatus: this.cssAnimationStatus(),
             attachDetachEvent: this.attachDetachEvent(),
             state: this.state(),
@@ -176,14 +175,13 @@ export class RdxPopoverRootDirective {
         if (state === this.state()) {
             return;
         }
-        isRdxPopoverDevMode() && console.log(this.uniqueId(), '[setState]', state, this.getAnimationParamsSnapshot());
         this.state.set(state);
     }
 
     /** @ignore */
     private openContent(): void {
         this.popoverContentDirective().open();
-        if (!this.cssAnimation() || !this.cssOpenAnimation()) {
+        if (!this.cssAnimation() || !this.cssOpeningAnimation()) {
             this.cssAnimationStatus.set(null);
         }
     }
@@ -191,7 +189,7 @@ export class RdxPopoverRootDirective {
     /** @ignore */
     private closeContent(): void {
         this.popoverContentDirective().close();
-        if (!this.cssAnimation() || !this.cssCloseAnimation()) {
+        if (!this.cssAnimation() || !this.cssClosingAnimation()) {
             this.cssAnimationStatus.set(null);
         }
     }
@@ -211,13 +209,13 @@ export class RdxPopoverRootDirective {
         return (
             !this.popoverContentAttributesDirective() ||
             !this.cssAnimation() ||
-            (this.cssAnimation() && !this.cssCloseAnimation() && state === RdxPopoverState.CLOSED) ||
-            (this.cssAnimation() && !this.cssOpenAnimation() && state === RdxPopoverState.OPEN) ||
+            (this.cssAnimation() && !this.cssClosingAnimation() && state === RdxPopoverState.CLOSED) ||
+            (this.cssAnimation() && !this.cssOpeningAnimation() && state === RdxPopoverState.OPEN) ||
             // !this.cssAnimationStatus() ||
-            (this.cssOpenAnimation() &&
+            (this.cssOpeningAnimation() &&
                 state === RdxPopoverState.OPEN &&
                 [RdxPopoverAnimationStatus.OPEN_STARTED].includes(this.cssAnimationStatus()!)) ||
-            (this.cssCloseAnimation() &&
+            (this.cssClosingAnimation() &&
                 state === RdxPopoverState.CLOSED &&
                 [RdxPopoverAnimationStatus.CLOSED_STARTED].includes(this.cssAnimationStatus()!))
         );
@@ -229,10 +227,10 @@ export class RdxPopoverRootDirective {
             this.popoverContentAttributesDirective() &&
             this.cssAnimation() &&
             cssAnimationStatus &&
-            ((this.cssOpenAnimation() &&
+            ((this.cssOpeningAnimation() &&
                 this.state() === RdxPopoverState.OPEN &&
                 [RdxPopoverAnimationStatus.OPEN_ENDED].includes(cssAnimationStatus)) ||
-                (this.cssCloseAnimation() &&
+                (this.cssClosingAnimation() &&
                     this.state() === RdxPopoverState.CLOSED &&
                     [RdxPopoverAnimationStatus.CLOSED_ENDED].includes(cssAnimationStatus)))
         );
@@ -255,12 +253,12 @@ export class RdxPopoverRootDirective {
     private canEmitOnOpenOrOnClosed() {
         return (
             !this.cssAnimation() ||
-            (!this.cssOpenAnimation() && this.state() === RdxPopoverState.OPEN) ||
-            (this.cssOpenAnimation() &&
+            (!this.cssOpeningAnimation() && this.state() === RdxPopoverState.OPEN) ||
+            (this.cssOpeningAnimation() &&
                 this.state() === RdxPopoverState.OPEN &&
                 this.cssAnimationStatus() === RdxPopoverAnimationStatus.OPEN_ENDED) ||
-            (!this.cssCloseAnimation() && this.state() === RdxPopoverState.CLOSED) ||
-            (this.cssCloseAnimation() &&
+            (!this.cssClosingAnimation() && this.state() === RdxPopoverState.CLOSED) ||
+            (this.cssClosingAnimation() &&
                 this.state() === RdxPopoverState.CLOSED &&
                 this.cssAnimationStatus() === RdxPopoverAnimationStatus.CLOSED_ENDED)
         );
@@ -279,8 +277,6 @@ export class RdxPopoverRootDirective {
                 if (!this.ifOpenOrCloseWithoutAnimations(state)) {
                     return;
                 }
-                isRdxPopoverDevMode() &&
-                    console.log(this.uniqueId(), '[onStateChangeEffect]', state, this.getAnimationParamsSnapshot());
                 this.openOrClose(state);
             });
         }, {});
@@ -299,14 +295,6 @@ export class RdxPopoverRootDirective {
                 if (!this.ifOpenOrCloseWithAnimations(cssAnimationStatus)) {
                     return;
                 }
-                isRdxPopoverDevMode() &&
-                    console.log(
-                        this.uniqueId(),
-                        '[onCssAnimationStatusChangeChangeEffect]',
-                        cssAnimationStatus,
-                        this.state(),
-                        this.getAnimationParamsSnapshot()
-                    );
                 this.openOrClose(this.state());
             });
         });
@@ -316,27 +304,17 @@ export class RdxPopoverRootDirective {
     private emitOpenOrClosedEventEffect() {
         let isFirst = true;
         effect(() => {
-            const listenedConditions = {
-                attachDetachEvent: this.attachDetachEvent(),
-                cssAnimationStatus: this.cssAnimationStatus()
-            };
-            if (isFirst) {
-                isFirst = false;
-                return;
-            }
+            this.attachDetachEvent();
+            this.cssAnimationStatus();
             untracked(() => {
+                if (isFirst) {
+                    isFirst = false;
+                    return;
+                }
                 const canEmitOpenClose = untracked(() => this.canEmitOnOpenOrOnClosed());
                 if (!canEmitOpenClose) {
                     return;
                 }
-                isRdxPopoverDevMode() &&
-                    console.log(
-                        this.uniqueId(),
-                        '[emitOpenOrClosedEventEffect]',
-                        canEmitOpenClose,
-                        listenedConditions,
-                        this.getAnimationParamsSnapshot()
-                    );
                 this.emitOnOpenOrOnClosed(this.state());
             });
         });
@@ -361,13 +339,6 @@ export class RdxPopoverRootDirective {
                     effectRef.destroy();
                     return;
                 }
-                isRdxPopoverDevMode() &&
-                    console.log(
-                        this.uniqueId(),
-                        '[onIsFirstDefaultOpenChangeEffect]',
-                        defaultOpen,
-                        this.getAnimationParamsSnapshot()
-                    );
                 this.handleOpen();
             });
         });

--- a/packages/primitives/popover/src/popover-root.directive.ts
+++ b/packages/primitives/popover/src/popover-root.directive.ts
@@ -55,11 +55,11 @@ export class RdxPopoverRootDirective implements OnInit {
     /**
      * TODO: create a dedicated transformer
      */
-    readonly cssAnimation = input<boolean | 'custom'>(true);
+    readonly cssAnimation = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
     /** @ignore */
-    readonly cssOnShowAnimation = input<boolean, BooleanInput>(true, { transform: booleanAttribute });
+    readonly cssOnShowAnimation = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
     /** @ignore */
-    readonly cssOnCloseAnimation = input<boolean, BooleanInput>(true, { transform: booleanAttribute });
+    readonly cssOnCloseAnimation = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
     /**
      * Event handler called when the open state of the popover changes.
@@ -247,13 +247,6 @@ export class RdxPopoverRootDirective implements OnInit {
         const isOpen = this.isOpen(state);
         isOpen ? this.show() : this.hide();
         this.onOpenChange.emit(isOpen);
-        this.document.dispatchEvent(
-            new CustomEvent(`popover.${isOpen ? 'open' : 'close'}`, {
-                detail: {
-                    id: this.name()
-                }
-            })
-        );
     }
 
     /** @ignore */

--- a/packages/primitives/popover/src/popover-trigger.directive.ts
+++ b/packages/primitives/popover/src/popover-trigger.directive.ts
@@ -18,7 +18,7 @@ import { injectPopoverRoot } from './popover-root.inject';
 })
 export class RdxPopoverTriggerDirective {
     /** @ignore */
-    readonly popoverRoot = injectPopoverRoot();
+    protected readonly popoverRoot = injectPopoverRoot();
     /** @ignore */
     readonly elementRef = inject(ElementRef);
     /** @ignore */

--- a/packages/primitives/popover/src/popover.types.ts
+++ b/packages/primitives/popover/src/popover.types.ts
@@ -18,6 +18,11 @@ export enum RdxPopoverState {
     CLOSED = 'closed'
 }
 
+export enum RdxPopoverAttachDetachEvent {
+    ATTACH = 'attach',
+    DETACH = 'detach'
+}
+
 export enum AnimationType {
     START = 'animationstart',
     END = 'animationend'

--- a/packages/primitives/popover/src/popover.types.ts
+++ b/packages/primitives/popover/src/popover.types.ts
@@ -23,11 +23,6 @@ export enum RdxPopoverAttachDetachEvent {
     DETACH = 'detach'
 }
 
-export enum AnimationType {
-    START = 'animationstart',
-    END = 'animationend'
-}
-
 export enum RdxPopoverAnimationStatus {
     OPEN_STARTED = 'open_started',
     OPEN_ENDED = 'open_ended',

--- a/packages/primitives/popover/src/popover.types.ts
+++ b/packages/primitives/popover/src/popover.types.ts
@@ -13,7 +13,22 @@ export enum RdxPopoverAlign {
     End = 'end'
 }
 
-export type RdxPopoverState = 'open' | 'closed';
+export enum RdxPopoverState {
+    OPEN = 'open',
+    CLOSED = 'closed'
+}
+
+export enum AnimationType {
+    START = 'animationstart',
+    END = 'animationend'
+}
+
+export enum RdxPopoverAnimationStatus {
+    OPEN_STARTED = 'open_started',
+    OPEN_ENDED = 'open_ended',
+    CLOSED_STARTED = 'closed_started',
+    CLOSED_ENDED = 'closed_ended'
+}
 
 export type RdxSideAndAlign = { side: RdxPopoverSide; align: RdxPopoverAlign };
 export type RdxSideAndAlignOffsets = { sideOffset: number; alignOffset: number };
@@ -31,8 +46,6 @@ export type RdxAllPossibleConnectedPositions = ReadonlyMap<
 
 export type RdxArrowPositionParams = {
     top: string;
-    bottom: string;
     left: string;
-    right: string;
     transform: string;
 };

--- a/packages/primitives/popover/src/popover.utils.ts
+++ b/packages/primitives/popover/src/popover.utils.ts
@@ -98,11 +98,9 @@ export function getArrowPositionParams(
     arrowWidthAndHeight: { width: number; height: number },
     triggerWidthAndHeight: { width: number; height: number }
 ): RdxArrowPositionParams {
-    const posParams = {
+    const posParams: RdxArrowPositionParams = {
         top: '',
-        bottom: '',
         left: '',
-        right: '',
         transform: ''
     };
 
@@ -119,11 +117,11 @@ export function getArrowPositionParams(
         } else if (sideAndAlign.align === RdxPopoverAlign.Center) {
             posParams.left = `calc(50% - ${arrowWidthAndHeight.width / 2}px)`;
         } else if (sideAndAlign.align === RdxPopoverAlign.End) {
-            posParams.right = `${(triggerWidthAndHeight.width - arrowWidthAndHeight.width) / 2}px`;
+            posParams.left = `calc(100% - ${(triggerWidthAndHeight.width + arrowWidthAndHeight.width) / 2}px)`;
         }
     } else if ([RdxPopoverSide.Left, RdxPopoverSide.Right].includes(sideAndAlign.side)) {
         if (sideAndAlign.side === RdxPopoverSide.Left) {
-            posParams.right = `-${arrowWidthAndHeight.width}px`;
+            posParams.left = `100%`;
             posParams.transform = `rotate(-90deg) translate(0, -50%)`;
         } else {
             posParams.left = `-${arrowWidthAndHeight.width}px`;
@@ -135,9 +133,13 @@ export function getArrowPositionParams(
         } else if (sideAndAlign.align === RdxPopoverAlign.Center) {
             posParams.top = `calc(50% - ${arrowWidthAndHeight.height / 2}px)`;
         } else if (sideAndAlign.align === RdxPopoverAlign.End) {
-            posParams.bottom = `${(triggerWidthAndHeight.height - arrowWidthAndHeight.height) / 2}px`;
+            posParams.top = `calc(100% - ${(triggerWidthAndHeight.height + arrowWidthAndHeight.height) / 2}px)`;
         }
     }
 
     return posParams;
+}
+
+export function isRdxPopoverDevMode() {
+    return localStorage.getItem('RDX_POPOVER_DEV_MODE') === '1';
 }

--- a/packages/primitives/popover/src/popover.utils.ts
+++ b/packages/primitives/popover/src/popover.utils.ts
@@ -139,7 +139,3 @@ export function getArrowPositionParams(
 
     return posParams;
 }
-
-export function isRdxPopoverDevMode() {
-    return localStorage.getItem('RDX_POPOVER_DEV_MODE') === '1';
-}

--- a/packages/primitives/popover/stories/popover-animations.component.ts
+++ b/packages/primitives/popover/stories/popover-animations.component.ts
@@ -1,0 +1,364 @@
+import { NgClass } from '@angular/common';
+import { Component, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
+import { RdxPopoverAlign, RdxPopoverModule } from '../index';
+import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
+import { RdxPopoverSide } from '../src/popover.types';
+
+@Component({
+    selector: 'rdx-popover-animations',
+    standalone: true,
+    imports: [
+        FormsModule,
+        RdxPopoverModule,
+        LucideAngularModule,
+        RdxPopoverContentAttributesComponent,
+        NgClass
+    ],
+    styles: `
+        .container {
+            height: 150px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        /* reset */
+        .reset {
+            all: unset;
+        }
+
+        .PopoverContent {
+            border-radius: 4px;
+            padding: 20px;
+            width: 260px;
+            background-color: white;
+            box-shadow:
+                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
+                hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
+        }
+
+        .PopoverContent:focus {
+            box-shadow:
+                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
+                hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
+                0 0 0 2px var(--violet-7);
+        }
+
+        .PopoverArrow {
+            fill: white;
+        }
+
+        .PopoverClose {
+            font-family: inherit;
+            border-radius: 100%;
+            height: 25px;
+            width: 25px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--violet-11);
+            position: absolute;
+            top: 5px;
+            right: 5px;
+        }
+
+        .PopoverClose:hover {
+            background-color: var(--violet-4);
+        }
+
+        .PopoverClose:focus {
+            box-shadow: 0 0 0 2px var(--violet-7);
+        }
+
+        .IconButton {
+            font-family: inherit;
+            border-radius: 100%;
+            height: 35px;
+            width: 35px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--violet-11);
+            background-color: white;
+            box-shadow: 0 2px 10px var(--black-a7);
+        }
+
+        .IconButton:hover {
+            background-color: var(--violet-3);
+        }
+
+        .IconButton:focus {
+            box-shadow: 0 0 0 2px black;
+        }
+
+        .Fieldset {
+            display: flex;
+            gap: 20px;
+            align-items: center;
+        }
+
+        .Label {
+            font-size: 13px;
+            color: var(--violet-11);
+            width: 75px;
+        }
+
+        .Input {
+            width: 100%;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            flex: 1;
+            border-radius: 4px;
+            padding: 0 10px;
+            font-size: 13px;
+            line-height: 1;
+            color: var(--violet-11);
+            box-shadow: 0 0 0 1px var(--violet-7);
+            height: 25px;
+        }
+
+        .Input:focus {
+            box-shadow: 0 0 0 2px var(--violet-8);
+        }
+
+        .Text {
+            margin: 0;
+            color: var(--mauve-12);
+            font-size: 15px;
+            line-height: 19px;
+            font-weight: 500;
+        }
+
+        /* =============== Params layout =============== */
+
+        .ParamsContainer {
+            display: flex;
+            column-gap: 8px;
+            color: var(--white-a12);
+            margin-bottom: 32px;
+        }
+
+        /* =============== Custom Animation =============== */
+
+        /* Open animations */
+
+        .rdx-custom-animated-content {
+            &:is(.rdx-custom-animated-content-open, .rdx-custom-animated-content-close) {
+                animation-duration: 400ms;
+                animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+                will-change: transform, opacity;
+            }
+
+            &.rdx-custom-animated-content-open {
+                &[data-state='open'][data-side='top'] {
+                    animation-name: rdxCustomSlideDownAndFade;
+                }
+
+                &[data-state='open'][data-side='right'] {
+                    animation-name: rdxCustomSlideLeftAndFade;
+                }
+
+                &[data-state='open'][data-side='bottom'] {
+                    animation-name: rdxCustomSlideUpAndFade;
+                }
+
+                &[data-state='open'][data-side='left'] {
+                    animation-name: rdxCustomSlideRightAndFade;
+                }
+            }
+
+            &.rdx-custom-animated-content-close {
+                &[data-state='closed'][data-side='top'] {
+                    animation-name: rdxCustomSlideDownAndFadeReverse;
+                }
+
+                &[data-state='closed'][data-side='right'] {
+                    animation-name: rdxCustomSlideLeftAndFadeReverse;
+                }
+
+                &[data-state='closed'][data-side='bottom'] {
+                    animation-name: rdxCustomSlideUpAndFadeReverse;
+                }
+
+                &[data-state='closed'][data-side='left'] {
+                    animation-name: rdxCustomSlideRightAndFadeReverse;
+                }
+            }
+        }
+
+        @keyframes rdxCustomSlideUpAndFade {
+            from {
+                opacity: 0;
+                transform: translateY(2px);
+                /*transition:left 1s linear;*/
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        @keyframes rdxCustomSlideRightAndFade {
+            from {
+                opacity: 0;
+                transform: translateX(-2px);
+            }
+            to {
+                opacity: 1;
+                transform: translateX(0);
+            }
+        }
+
+        @keyframes rdxCustomSlideDownAndFade {
+            from {
+                opacity: 0;
+                transform: translateY(-2px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        @keyframes rdxCustomSlideLeftAndFade {
+            from {
+                opacity: 0;
+                transform: translateX(2px);
+            }
+            to {
+                opacity: 1;
+                transform: translateX(0);
+            }
+        }
+
+        /* Close animations */
+
+        @keyframes rdxCustomSlideUpAndFadeReverse {
+            from {
+                opacity: 1;
+                transform: translateY(0);
+            }
+            to {
+                opacity: 0;
+                transform: translateY(2px);
+            }
+        }
+
+        @keyframes rdxCustomSlideRightAndFadeReverse {
+            from {
+                opacity: 1;
+                transform: translateX(0);
+            }
+            to {
+                opacity: 0;
+                transform: translateX(-2px);
+            }
+        }
+
+        @keyframes rdxCustomSlideDownAndFadeReverse {
+            from {
+                opacity: 1;
+                transform: translateY(0);
+            }
+            to {
+                opacity: 0;
+                transform: translateY(-2px);
+            }
+        }
+
+        @keyframes rdxCustomSlideLeftAndFadeReverse {
+            from {
+                opacity: 1;
+                transform: translateX(0);
+            }
+            to {
+                opacity: 0;
+                transform: translateX(2px);
+            }
+        }
+    `,
+    template: `
+        <div class="ParamsContainer">
+            CSS Animation:
+            <select
+                [ngModel]="cssAnimation()"
+                (ngModelChange)="cssAnimation.set($event === 'true' ? true : $event === 'false' ? false : $event)"
+            >
+                <option [value]="true">{{ 'true' }}</option>
+                <option [value]="false">{{ 'false' }}</option>
+                <option [value]="'custom'">{{ '"custom"' }}</option>
+            </select>
+            On Show Animation:
+            <input [ngModel]="cssOnShowAnimation()" (ngModelChange)="cssOnShowAnimation.set($event)" type="checkbox" />
+            On Close Animation:
+            <input
+                [ngModel]="cssOnCloseAnimation()"
+                (ngModelChange)="cssOnCloseAnimation.set($event)"
+                type="checkbox"
+            />
+        </div>
+
+        <div class="container">
+            <ng-container
+                [cssAnimation]="cssAnimation()"
+                [cssOnShowAnimation]="cssOnShowAnimation()"
+                [cssOnCloseAnimation]="cssOnCloseAnimation()"
+                rdxPopoverRoot
+            >
+                <button class="IconButton reset" rdxPopoverTrigger>
+                    <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
+                </button>
+
+                <ng-template rdxPopoverContent>
+                    <div
+                        class="PopoverContent"
+                        [ngClass]="{
+                            'rdx-custom-animated-content': cssAnimation() === 'custom',
+                            'rdx-custom-animated-content-open': cssAnimation() === 'custom' && cssOnShowAnimation(),
+                            'rdx-custom-animated-content-close': cssAnimation() === 'custom' && cssOnCloseAnimation()
+                        }"
+                        rdxPopoverContentAttributes
+                    >
+                        <button class="PopoverClose reset" rdxPopoverClose aria-label="Close">
+                            <lucide-angular [img]="XIcon" size="16" style="display: flex" />
+                        </button>
+                        <div style="display: flex; flex-direction: column; gap: 10px">
+                            <p class="Text" style="margin-bottom: 10px">Dimensions</p>
+                            <fieldset class="reset Fieldset">
+                                <label class="Label" for="width">Width</label>
+                                <input class="reset Input" id="width" value="100%" />
+                            </fieldset>
+                            <fieldset class="reset Fieldset">
+                                <label class="Label" for="maxWidth">Max. width</label>
+                                <input class="reset Input" id="maxWidth" value="300px" />
+                            </fieldset>
+                            <fieldset class="reset Fieldset">
+                                <label class="Label" for="height">Height</label>
+                                <input class="reset Input" id="height" value="25px" />
+                            </fieldset>
+                            <fieldset class="reset Fieldset">
+                                <label class="Label" for="maxHeight">Max. height</label>
+                                <input class="reset Input" id="maxHeight" value="none" />
+                            </fieldset>
+                        </div>
+                        <div class="PopoverArrow" rdxPopoverArrow></div>
+                    </div>
+                </ng-template>
+            </ng-container>
+        </div>
+    `
+})
+export class RdxPopoverAnimationsComponent {
+    readonly MountainSnowIcon = MountainSnowIcon;
+    readonly XIcon = X;
+
+    cssAnimation = signal<boolean | 'custom'>(true);
+    cssOnShowAnimation = signal(true);
+    cssOnCloseAnimation = signal(true);
+
+    readonly sides = RdxPopoverSide;
+    readonly aligns = RdxPopoverAlign;
+}

--- a/packages/primitives/popover/stories/popover-animations.component.ts
+++ b/packages/primitives/popover/stories/popover-animations.component.ts
@@ -1,4 +1,3 @@
-import { NgClass } from '@angular/common';
 import { Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
@@ -16,40 +15,29 @@ import { PopoverWithEventBaseComponent } from './popover-with-event-base.compone
         RdxPopoverModule,
         LucideAngularModule,
         RdxPopoverContentAttributesComponent,
-        NgClass,
         PopoverWithEventBaseComponent
     ],
     styles: styles(true),
     template: `
         <popover-with-event-base>
             <div class="ParamsContainer">
-                CSS Animation:
-                <select
-                    [ngModel]="cssAnimation()"
-                    (ngModelChange)="cssAnimation.set($event === 'true' ? true : $event === 'false' ? false : $event)"
-                >
-                    <option [value]="true">{{ 'true' }}</option>
-                    <option [value]="false">{{ 'false' }}</option>
-                </select>
-                On Show Animation:
+                <input [ngModel]="cssAnimation()" (ngModelChange)="cssAnimation.set($event)" type="checkbox" />
+                CSS Animation
+                <input [ngModel]="cssOpenAnimation()" (ngModelChange)="cssOpenAnimation.set($event)" type="checkbox" />
+                On Open Animation
                 <input
-                    [ngModel]="cssOnShowAnimation()"
-                    (ngModelChange)="cssOnShowAnimation.set($event)"
+                    [ngModel]="cssCloseAnimation()"
+                    (ngModelChange)="cssCloseAnimation.set($event)"
                     type="checkbox"
                 />
-                On Close Animation:
-                <input
-                    [ngModel]="cssOnCloseAnimation()"
-                    (ngModelChange)="cssOnCloseAnimation.set($event)"
-                    type="checkbox"
-                />
+                On Close Animation
             </div>
 
             <div class="container">
                 <ng-container
                     [cssAnimation]="cssAnimation()"
-                    [cssOnShowAnimation]="cssOnShowAnimation()"
-                    [cssOnCloseAnimation]="cssOnCloseAnimation()"
+                    [cssOpenAnimation]="cssOpenAnimation()"
+                    [cssCloseAnimation]="cssCloseAnimation()"
                     rdxPopoverRoot
                 >
                     <button class="IconButton reset" rdxPopoverTrigger>
@@ -57,16 +45,7 @@ import { PopoverWithEventBaseComponent } from './popover-with-event-base.compone
                     </button>
 
                     <ng-template rdxPopoverContent>
-                        <div
-                            class="PopoverContent"
-                            [ngClass]="{
-                                'rdx-custom-animated-content': cssAnimation() === 'custom',
-                                'rdx-custom-animated-content-open': cssAnimation() === 'custom' && cssOnShowAnimation(),
-                                'rdx-custom-animated-content-close':
-                                    cssAnimation() === 'custom' && cssOnCloseAnimation()
-                            }"
-                            rdxPopoverContentAttributes
-                        >
+                        <div class="PopoverContent" rdxPopoverContentAttributes>
                             <button class="PopoverClose reset" rdxPopoverClose aria-label="Close">
                                 <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                             </button>
@@ -105,6 +84,6 @@ export class RdxPopoverAnimationsComponent {
     readonly aligns = RdxPopoverAlign;
 
     cssAnimation = signal<boolean>(true);
-    cssOnShowAnimation = signal(true);
-    cssOnCloseAnimation = signal(true);
+    cssOpenAnimation = signal(true);
+    cssCloseAnimation = signal(true);
 }

--- a/packages/primitives/popover/stories/popover-animations.component.ts
+++ b/packages/primitives/popover/stories/popover-animations.component.ts
@@ -5,6 +5,8 @@ import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverAlign, RdxPopoverModule } from '../index';
 import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
 import { RdxPopoverSide } from '../src/popover.types';
+import styles from './popover-styles.constants';
+import { PopoverWithEventBaseComponent } from './popover-with-event-base.component';
 
 @Component({
     selector: 'rdx-popover-animations',
@@ -14,351 +16,95 @@ import { RdxPopoverSide } from '../src/popover.types';
         RdxPopoverModule,
         LucideAngularModule,
         RdxPopoverContentAttributesComponent,
-        NgClass
+        NgClass,
+        PopoverWithEventBaseComponent
     ],
-    styles: `
-        .container {
-            height: 150px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
-
-        /* reset */
-        .reset {
-            all: unset;
-        }
-
-        .PopoverContent {
-            border-radius: 4px;
-            padding: 20px;
-            width: 260px;
-            background-color: white;
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-        }
-
-        .PopoverContent:focus {
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
-                0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverArrow {
-            fill: white;
-        }
-
-        .PopoverClose {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 25px;
-            width: 25px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            position: absolute;
-            top: 5px;
-            right: 5px;
-        }
-
-        .PopoverClose:hover {
-            background-color: var(--violet-4);
-        }
-
-        .PopoverClose:focus {
-            box-shadow: 0 0 0 2px var(--violet-7);
-        }
-
-        .IconButton {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 35px;
-            width: 35px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            background-color: white;
-            box-shadow: 0 2px 10px var(--black-a7);
-        }
-
-        .IconButton:hover {
-            background-color: var(--violet-3);
-        }
-
-        .IconButton:focus {
-            box-shadow: 0 0 0 2px black;
-        }
-
-        .Fieldset {
-            display: flex;
-            gap: 20px;
-            align-items: center;
-        }
-
-        .Label {
-            font-size: 13px;
-            color: var(--violet-11);
-            width: 75px;
-        }
-
-        .Input {
-            width: 100%;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            flex: 1;
-            border-radius: 4px;
-            padding: 0 10px;
-            font-size: 13px;
-            line-height: 1;
-            color: var(--violet-11);
-            box-shadow: 0 0 0 1px var(--violet-7);
-            height: 25px;
-        }
-
-        .Input:focus {
-            box-shadow: 0 0 0 2px var(--violet-8);
-        }
-
-        .Text {
-            margin: 0;
-            color: var(--mauve-12);
-            font-size: 15px;
-            line-height: 19px;
-            font-weight: 500;
-        }
-
-        /* =============== Params layout =============== */
-
-        .ParamsContainer {
-            display: flex;
-            column-gap: 8px;
-            color: var(--white-a12);
-            margin-bottom: 32px;
-        }
-
-        /* =============== Custom Animation =============== */
-
-        /* Open animations */
-
-        .rdx-custom-animated-content {
-            &:is(.rdx-custom-animated-content-open, .rdx-custom-animated-content-close) {
-                animation-duration: 400ms;
-                animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-                will-change: transform, opacity;
-            }
-
-            &.rdx-custom-animated-content-open {
-                &[data-state='open'][data-side='top'] {
-                    animation-name: rdxCustomSlideDownAndFade;
-                }
-
-                &[data-state='open'][data-side='right'] {
-                    animation-name: rdxCustomSlideLeftAndFade;
-                }
-
-                &[data-state='open'][data-side='bottom'] {
-                    animation-name: rdxCustomSlideUpAndFade;
-                }
-
-                &[data-state='open'][data-side='left'] {
-                    animation-name: rdxCustomSlideRightAndFade;
-                }
-            }
-
-            &.rdx-custom-animated-content-close {
-                &[data-state='closed'][data-side='top'] {
-                    animation-name: rdxCustomSlideDownAndFadeReverse;
-                }
-
-                &[data-state='closed'][data-side='right'] {
-                    animation-name: rdxCustomSlideLeftAndFadeReverse;
-                }
-
-                &[data-state='closed'][data-side='bottom'] {
-                    animation-name: rdxCustomSlideUpAndFadeReverse;
-                }
-
-                &[data-state='closed'][data-side='left'] {
-                    animation-name: rdxCustomSlideRightAndFadeReverse;
-                }
-            }
-        }
-
-        @keyframes rdxCustomSlideUpAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(2px);
-                /*transition:left 1s linear;*/
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes rdxCustomSlideRightAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        @keyframes rdxCustomSlideDownAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes rdxCustomSlideLeftAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        /* Close animations */
-
-        @keyframes rdxCustomSlideUpAndFadeReverse {
-            from {
-                opacity: 1;
-                transform: translateY(0);
-            }
-            to {
-                opacity: 0;
-                transform: translateY(2px);
-            }
-        }
-
-        @keyframes rdxCustomSlideRightAndFadeReverse {
-            from {
-                opacity: 1;
-                transform: translateX(0);
-            }
-            to {
-                opacity: 0;
-                transform: translateX(-2px);
-            }
-        }
-
-        @keyframes rdxCustomSlideDownAndFadeReverse {
-            from {
-                opacity: 1;
-                transform: translateY(0);
-            }
-            to {
-                opacity: 0;
-                transform: translateY(-2px);
-            }
-        }
-
-        @keyframes rdxCustomSlideLeftAndFadeReverse {
-            from {
-                opacity: 1;
-                transform: translateX(0);
-            }
-            to {
-                opacity: 0;
-                transform: translateX(2px);
-            }
-        }
-    `,
+    styles: styles(true),
     template: `
-        <div class="ParamsContainer">
-            CSS Animation:
-            <select
-                [ngModel]="cssAnimation()"
-                (ngModelChange)="cssAnimation.set($event === 'true' ? true : $event === 'false' ? false : $event)"
-            >
-                <option [value]="true">{{ 'true' }}</option>
-                <option [value]="false">{{ 'false' }}</option>
-                <option [value]="'custom'">{{ '"custom"' }}</option>
-            </select>
-            On Show Animation:
-            <input [ngModel]="cssOnShowAnimation()" (ngModelChange)="cssOnShowAnimation.set($event)" type="checkbox" />
-            On Close Animation:
-            <input
-                [ngModel]="cssOnCloseAnimation()"
-                (ngModelChange)="cssOnCloseAnimation.set($event)"
-                type="checkbox"
-            />
-        </div>
+        <popover-with-event-base>
+            <div class="ParamsContainer">
+                CSS Animation:
+                <select
+                    [ngModel]="cssAnimation()"
+                    (ngModelChange)="cssAnimation.set($event === 'true' ? true : $event === 'false' ? false : $event)"
+                >
+                    <option [value]="true">{{ 'true' }}</option>
+                    <option [value]="false">{{ 'false' }}</option>
+                </select>
+                On Show Animation:
+                <input
+                    [ngModel]="cssOnShowAnimation()"
+                    (ngModelChange)="cssOnShowAnimation.set($event)"
+                    type="checkbox"
+                />
+                On Close Animation:
+                <input
+                    [ngModel]="cssOnCloseAnimation()"
+                    (ngModelChange)="cssOnCloseAnimation.set($event)"
+                    type="checkbox"
+                />
+            </div>
 
-        <div class="container">
-            <ng-container
-                [cssAnimation]="cssAnimation()"
-                [cssOnShowAnimation]="cssOnShowAnimation()"
-                [cssOnCloseAnimation]="cssOnCloseAnimation()"
-                rdxPopoverRoot
-            >
-                <button class="IconButton reset" rdxPopoverTrigger>
-                    <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
-                </button>
+            <div class="container">
+                <ng-container
+                    [cssAnimation]="cssAnimation()"
+                    [cssOnShowAnimation]="cssOnShowAnimation()"
+                    [cssOnCloseAnimation]="cssOnCloseAnimation()"
+                    rdxPopoverRoot
+                >
+                    <button class="IconButton reset" rdxPopoverTrigger>
+                        <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
+                    </button>
 
-                <ng-template rdxPopoverContent>
-                    <div
-                        class="PopoverContent"
-                        [ngClass]="{
-                            'rdx-custom-animated-content': cssAnimation() === 'custom',
-                            'rdx-custom-animated-content-open': cssAnimation() === 'custom' && cssOnShowAnimation(),
-                            'rdx-custom-animated-content-close': cssAnimation() === 'custom' && cssOnCloseAnimation()
-                        }"
-                        rdxPopoverContentAttributes
-                    >
-                        <button class="PopoverClose reset" rdxPopoverClose aria-label="Close">
-                            <lucide-angular [img]="XIcon" size="16" style="display: flex" />
-                        </button>
-                        <div style="display: flex; flex-direction: column; gap: 10px">
-                            <p class="Text" style="margin-bottom: 10px">Dimensions</p>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="width">Width</label>
-                                <input class="reset Input" id="width" value="100%" />
-                            </fieldset>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="maxWidth">Max. width</label>
-                                <input class="reset Input" id="maxWidth" value="300px" />
-                            </fieldset>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="height">Height</label>
-                                <input class="reset Input" id="height" value="25px" />
-                            </fieldset>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="maxHeight">Max. height</label>
-                                <input class="reset Input" id="maxHeight" value="none" />
-                            </fieldset>
+                    <ng-template rdxPopoverContent>
+                        <div
+                            class="PopoverContent"
+                            [ngClass]="{
+                                'rdx-custom-animated-content': cssAnimation() === 'custom',
+                                'rdx-custom-animated-content-open': cssAnimation() === 'custom' && cssOnShowAnimation(),
+                                'rdx-custom-animated-content-close':
+                                    cssAnimation() === 'custom' && cssOnCloseAnimation()
+                            }"
+                            rdxPopoverContentAttributes
+                        >
+                            <button class="PopoverClose reset" rdxPopoverClose aria-label="Close">
+                                <lucide-angular [img]="XIcon" size="16" style="display: flex" />
+                            </button>
+                            <div style="display: flex; flex-direction: column; gap: 10px">
+                                <p class="Text" style="margin-bottom: 10px">Dimensions</p>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="width">Width</label>
+                                    <input class="reset Input" id="width" value="100%" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxWidth">Max. width</label>
+                                    <input class="reset Input" id="maxWidth" value="300px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="height">Height</label>
+                                    <input class="reset Input" id="height" value="25px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxHeight">Max. height</label>
+                                    <input class="reset Input" id="maxHeight" value="none" />
+                                </fieldset>
+                            </div>
+                            <div class="PopoverArrow" rdxPopoverArrow></div>
                         </div>
-                        <div class="PopoverArrow" rdxPopoverArrow></div>
-                    </div>
-                </ng-template>
-            </ng-container>
-        </div>
+                    </ng-template>
+                </ng-container>
+            </div>
+        </popover-with-event-base>
     `
 })
 export class RdxPopoverAnimationsComponent {
     readonly MountainSnowIcon = MountainSnowIcon;
     readonly XIcon = X;
 
-    cssAnimation = signal<boolean | 'custom'>(true);
-    cssOnShowAnimation = signal(true);
-    cssOnCloseAnimation = signal(true);
-
     readonly sides = RdxPopoverSide;
     readonly aligns = RdxPopoverAlign;
+
+    cssAnimation = signal<boolean>(true);
+    cssOnShowAnimation = signal(true);
+    cssOnCloseAnimation = signal(true);
 }

--- a/packages/primitives/popover/stories/popover-animations.component.ts
+++ b/packages/primitives/popover/stories/popover-animations.component.ts
@@ -23,21 +23,25 @@ import { PopoverWithEventBaseComponent } from './popover-with-event-base.compone
             <div class="ParamsContainer">
                 <input [ngModel]="cssAnimation()" (ngModelChange)="cssAnimation.set($event)" type="checkbox" />
                 CSS Animation
-                <input [ngModel]="cssOpenAnimation()" (ngModelChange)="cssOpenAnimation.set($event)" type="checkbox" />
-                On Open Animation
                 <input
-                    [ngModel]="cssCloseAnimation()"
-                    (ngModelChange)="cssCloseAnimation.set($event)"
+                    [ngModel]="cssOpeningAnimation()"
+                    (ngModelChange)="cssOpeningAnimation.set($event)"
                     type="checkbox"
                 />
-                On Close Animation
+                On Opening Animation
+                <input
+                    [ngModel]="cssClosingAnimation()"
+                    (ngModelChange)="cssClosingAnimation.set($event)"
+                    type="checkbox"
+                />
+                On Closing Animation
             </div>
 
             <div class="container">
                 <ng-container
                     [cssAnimation]="cssAnimation()"
-                    [cssOpenAnimation]="cssOpenAnimation()"
-                    [cssCloseAnimation]="cssCloseAnimation()"
+                    [cssOpeningAnimation]="cssOpeningAnimation()"
+                    [cssClosingAnimation]="cssClosingAnimation()"
                     rdxPopoverRoot
                 >
                     <button class="IconButton reset" rdxPopoverTrigger>
@@ -84,6 +88,6 @@ export class RdxPopoverAnimationsComponent {
     readonly aligns = RdxPopoverAlign;
 
     cssAnimation = signal<boolean>(true);
-    cssOpenAnimation = signal(true);
-    cssCloseAnimation = signal(true);
+    cssOpeningAnimation = signal(true);
+    cssClosingAnimation = signal(true);
 }

--- a/packages/primitives/popover/stories/popover-default.component.ts
+++ b/packages/primitives/popover/stories/popover-default.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverModule } from '../index';
+import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
 
 @Component({
     selector: 'rdx-popover-default',
@@ -9,7 +10,8 @@ import { RdxPopoverModule } from '../index';
     imports: [
         FormsModule,
         RdxPopoverModule,
-        LucideAngularModule
+        LucideAngularModule,
+        RdxPopoverContentAttributesComponent
     ],
     styles: `
         .container {
@@ -34,9 +36,6 @@ import { RdxPopoverModule } from '../index';
             box-shadow:
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-            animation-duration: 400ms;
-            animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-            will-change: transform, opacity;
         }
 
         .PopoverContent:focus {
@@ -44,22 +43,6 @@ import { RdxPopoverModule } from '../index';
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
                 0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverContent[data-state='open'][data-side='top'] {
-            animation-name: slideDownAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='right'] {
-            animation-name: slideLeftAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='bottom'] {
-            animation-name: slideUpAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='left'] {
-            animation-name: slideRightAndFade;
         }
 
         .PopoverArrow {
@@ -147,50 +130,6 @@ import { RdxPopoverModule } from '../index';
             line-height: 19px;
             font-weight: 500;
         }
-
-        @keyframes slideUpAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideRightAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        @keyframes slideDownAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideLeftAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
     `,
     template: `
         <div class="container">
@@ -200,7 +139,7 @@ import { RdxPopoverModule } from '../index';
                 </button>
 
                 <ng-template rdxPopoverContent>
-                    <div class="PopoverContent">
+                    <div class="PopoverContent" rdxPopoverContentAttributes>
                         <button class="PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>

--- a/packages/primitives/popover/stories/popover-default.component.ts
+++ b/packages/primitives/popover/stories/popover-default.component.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverModule } from '../index';
 import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
+import styles from './popover-styles.constants';
 
 @Component({
     selector: 'rdx-popover-default',
@@ -13,153 +14,36 @@ import { RdxPopoverContentAttributesComponent } from '../src/popover-content-att
         LucideAngularModule,
         RdxPopoverContentAttributesComponent
     ],
-    styles: `
-        .container {
-            height: 150px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
-
-        /* reset */
-        button,
-        fieldset,
-        input {
-            all: unset;
-        }
-
-        .PopoverContent {
-            border-radius: 4px;
-            padding: 20px;
-            width: 260px;
-            background-color: white;
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-        }
-
-        .PopoverContent:focus {
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
-                0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverArrow {
-            fill: white;
-        }
-
-        .PopoverClose {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 25px;
-            width: 25px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            position: absolute;
-            top: 5px;
-            right: 5px;
-        }
-
-        .PopoverClose:hover {
-            background-color: var(--violet-4);
-        }
-
-        .PopoverClose:focus {
-            box-shadow: 0 0 0 2px var(--violet-7);
-        }
-
-        .IconButton {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 35px;
-            width: 35px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            background-color: white;
-            box-shadow: 0 2px 10px var(--black-a7);
-        }
-
-        .IconButton:hover {
-            background-color: var(--violet-3);
-        }
-
-        .IconButton:focus {
-            box-shadow: 0 0 0 2px black;
-        }
-
-        .Fieldset {
-            display: flex;
-            gap: 20px;
-            align-items: center;
-        }
-
-        .Label {
-            font-size: 13px;
-            color: var(--violet-11);
-            width: 75px;
-        }
-
-        .Input {
-            width: 100%;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            flex: 1;
-            border-radius: 4px;
-            padding: 0 10px;
-            font-size: 13px;
-            line-height: 1;
-            color: var(--violet-11);
-            box-shadow: 0 0 0 1px var(--violet-7);
-            height: 25px;
-        }
-
-        .Input:focus {
-            box-shadow: 0 0 0 2px var(--violet-8);
-        }
-
-        .Text {
-            margin: 0;
-            color: var(--mauve-12);
-            font-size: 15px;
-            line-height: 19px;
-            font-weight: 500;
-        }
-    `,
+    styles: styles(),
     template: `
         <div class="container">
             <ng-container rdxPopoverRoot>
-                <button class="IconButton" rdxPopoverTrigger>
+                <button class="reset IconButton" rdxPopoverTrigger>
                     <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
                 </button>
 
                 <ng-template rdxPopoverContent>
                     <div class="PopoverContent" rdxPopoverContentAttributes>
-                        <button class="PopoverClose" rdxPopoverClose aria-label="Close">
+                        <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>
                         <div style="display: flex; flex-direction: column; gap: 10px">
                             <p class="Text" style="margin-bottom: 10px">Dimensions</p>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="width">Width</label>
-                                <input class="Input" id="width" value="100%" />
+                                <input class="reset Input" id="width" value="100%" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="maxWidth">Max. width</label>
-                                <input class="Input" id="maxWidth" value="300px" />
+                                <input class="reset Input" id="maxWidth" value="300px" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="height">Height</label>
-                                <input class="Input" id="height" value="25px" />
+                                <input class="reset Input" id="height" value="25px" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="maxHeight">Max. height</label>
-                                <input class="Input" id="maxHeight" value="none" />
+                                <input class="reset Input" id="maxHeight" value="none" />
                             </fieldset>
                         </div>
                         <div class="PopoverArrow" rdxPopoverArrow></div>

--- a/packages/primitives/popover/stories/popover-events.components.ts
+++ b/packages/primitives/popover/stories/popover-events.components.ts
@@ -1,8 +1,10 @@
-import { Component, ElementRef, inject, signal, viewChild } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
 import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
+import styles from './popover-styles.constants';
+import { PopoverWithEventBaseComponent } from './popover-with-event-base.component';
 
 @Component({
     selector: 'rdx-popover-events',
@@ -11,251 +13,55 @@ import { RdxPopoverContentAttributesComponent } from '../src/popover-content-att
         RdxPopoverModule,
         LucideAngularModule,
         FormsModule,
-        RdxPopoverContentAttributesComponent
+        RdxPopoverContentAttributesComponent,
+        PopoverWithEventBaseComponent
     ],
     styles: `
-        .container {
-            height: 150px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
-
-        /* reset */
-        .reset {
-            all: unset;
-        }
-
-        .PopoverContent {
-            border-radius: 4px;
-            padding: 20px;
-            width: 260px;
-            background-color: white;
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-        }
-
-        .PopoverContent:focus {
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
-                0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverArrow {
-            fill: white;
-        }
-
-        .PopoverClose {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 25px;
-            width: 25px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            position: absolute;
-            top: 5px;
-            right: 5px;
-        }
-
-        .PopoverClose:hover {
-            background-color: var(--violet-4);
-        }
-
-        .PopoverClose:focus {
-            box-shadow: 0 0 0 2px var(--violet-7);
-        }
-
-        .IconButton {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 35px;
-            width: 35px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            background-color: white;
-            box-shadow: 0 2px 10px var(--black-a7);
-        }
-
-        .IconButton:hover {
-            background-color: var(--violet-3);
-        }
-
-        .IconButton:focus {
-            box-shadow: 0 0 0 2px black;
-        }
-
-        .Fieldset {
-            display: flex;
-            gap: 20px;
-            align-items: center;
-        }
-
-        .Label {
-            font-size: 13px;
-            color: var(--violet-11);
-            width: 75px;
-        }
-
-        .Input {
-            width: 100%;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            flex: 1;
-            border-radius: 4px;
-            padding: 0 10px;
-            font-size: 13px;
-            line-height: 1;
-            color: var(--violet-11);
-            box-shadow: 0 0 0 1px var(--violet-7);
-            height: 25px;
-        }
-
-        .Input:focus {
-            box-shadow: 0 0 0 2px var(--violet-8);
-        }
-
-        .Text {
-            margin: 0;
-            color: var(--mauve-12);
-            font-size: 15px;
-            line-height: 19px;
-            font-weight: 500;
-        }
-
-        .MessagesContainer {
-            padding: 20px;
-        }
-
-        .Message {
-            color: var(--white-a12);
-            font-size: 15px;
-            line-height: 19px;
-            font-weight: bolder;
-        }
-
-        /* =============== Params layout =============== */
-
-        .ParamsContainer {
-            display: flex;
-            column-gap: 8px;
-            color: var(--white-a12);
-            margin-bottom: 32px;
-        }
+        ${styles()}
     `,
     template: `
-        <div class="ParamsContainer">
-            (onEscapeKeyDown) prevent default:
-            <input
-                [ngModel]="onEscapeKeyDownPreventDefault()"
-                (ngModelChange)="onEscapeKeyDownPreventDefault.set($event)"
-                type="checkbox"
-            />
-            (onPointerDownOutside) prevent default:
-            <input
-                [ngModel]="onPointerDownOutsidePreventDefault()"
-                (ngModelChange)="onPointerDownOutsidePreventDefault.set($event)"
-                type="checkbox"
-            />
-        </div>
+        <popover-with-event-base>
+            <div class="container" #eventsContainer>
+                <ng-container rdxPopoverRoot>
+                    <button class="reset IconButton" #triggerElement rdxPopoverTrigger>
+                        <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
+                    </button>
 
-        <div class="container" #eventsContainer>
-            <ng-container rdxPopoverRoot>
-                <button class="reset IconButton" #triggerElement rdxPopoverTrigger>
-                    <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
-                </button>
-
-                <ng-template
-                    [sideOffset]="8"
-                    (onEscapeKeyDown)="onEscapeKeyDown($event)"
-                    (onPointerDownOutside)="onPointerDownOutside($event)"
-                    (onShow)="onShow()"
-                    (onHide)="onHide()"
-                    rdxPopoverContent
-                >
-                    <div class="PopoverContent" rdxPopoverContentAttributes>
-                        <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
-                            <lucide-angular [img]="XIcon" size="16" style="display: flex" />
-                        </button>
-                        <div style="display: flex; flex-direction: column; gap: 10px">
-                            <p class="Text" style="margin-bottom: 10px">Dimensions</p>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="width">Width</label>
-                                <input class="reset Input" id="width" value="100%" />
-                            </fieldset>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="maxWidth">Max. width</label>
-                                <input class="reset Input" id="maxWidth" value="300px" />
-                            </fieldset>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="height">Height</label>
-                                <input class="reset Input" id="height" value="25px" />
-                            </fieldset>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="maxHeight">Max. height</label>
-                                <input class="reset Input" id="maxHeight" value="none" />
-                            </fieldset>
+                    <ng-template [sideOffset]="8" rdxPopoverContent>
+                        <div class="PopoverContent" rdxPopoverContentAttributes>
+                            <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
+                                <lucide-angular [img]="XIcon" size="16" style="display: flex" />
+                            </button>
+                            <div style="display: flex; flex-direction: column; gap: 10px">
+                                <p class="Text" style="margin-bottom: 10px">Dimensions</p>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="width">Width</label>
+                                    <input class="reset Input" id="width" value="100%" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxWidth">Max. width</label>
+                                    <input class="reset Input" id="maxWidth" value="300px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="height">Height</label>
+                                    <input class="reset Input" id="height" value="25px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxHeight">Max. height</label>
+                                    <input class="reset Input" id="maxHeight" value="none" />
+                                </fieldset>
+                            </div>
+                            <div class="PopoverArrow" rdxPopoverArrow></div>
                         </div>
-                        <div class="PopoverArrow" rdxPopoverArrow></div>
-                    </div>
-                </ng-template>
-            </ng-container>
-        </div>
-        @if (messages().length) {
-            <div class="MessagesContainer">
-                @for (message of messages(); track message; let i = $index) {
-                    <p class="Message">{{ messages().length - i }}. {{ message }}</p>
-                }
+                    </ng-template>
+                </ng-container>
             </div>
-        }
+        </popover-with-event-base>
     `
 })
 export class RdxPopoverEventsComponent {
-    private elementRef = inject(ElementRef);
-
-    private readonly triggerElement = viewChild<ElementRef<HTMLElement>>('triggerElement');
-    private readonly eventsContainer = viewChild<ElementRef<HTMLElement>>('eventsContainer');
-
     readonly MountainSnowIcon = MountainSnowIcon;
     readonly XIcon = X;
-
-    readonly messages = signal<string[]>([]);
-
-    readonly onEscapeKeyDownPreventDefault = signal(false);
-    readonly onPointerDownOutsidePreventDefault = signal(false);
-
-    onEscapeKeyDown(event: KeyboardEvent) {
-        this.addMessage(`Escape clicked! (preventDefault: ${this.onEscapeKeyDownPreventDefault()})`);
-        this.onEscapeKeyDownPreventDefault() && event.preventDefault();
-    }
-
-    onPointerDownOutside(event: MouseEvent): void {
-        if (!event.target || !this.elementRef.nativeElement.contains(event.target as HTMLElement)) {
-            return;
-        }
-        this.addMessage(
-            `Mouse clicked outside the popover! (preventDefault: ${this.onPointerDownOutsidePreventDefault()})`
-        );
-        this.onPointerDownOutsidePreventDefault() && event.preventDefault();
-    }
-
-    onShow() {
-        this.addMessage('Popover shown!');
-    }
-
-    onHide() {
-        this.addMessage('Popover hidden!');
-    }
-
-    private addMessage(message: string) {
-        this.messages.update((messages) => [message, ...messages]);
-    }
 
     protected readonly sides = RdxPopoverSide;
     protected readonly aligns = RdxPopoverAlign;

--- a/packages/primitives/popover/stories/popover-events.components.ts
+++ b/packages/primitives/popover/stories/popover-events.components.ts
@@ -2,6 +2,7 @@ import { Component, ElementRef, inject, signal, viewChild } from '@angular/core'
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
+import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
 
 @Component({
     selector: 'rdx-popover-events',
@@ -9,7 +10,8 @@ import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
     imports: [
         RdxPopoverModule,
         LucideAngularModule,
-        FormsModule
+        FormsModule,
+        RdxPopoverContentAttributesComponent
     ],
     styles: `
         .container {
@@ -32,9 +34,6 @@ import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
             box-shadow:
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-            animation-duration: 400ms;
-            animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-            will-change: transform, opacity;
         }
 
         .PopoverContent:focus {
@@ -42,22 +41,6 @@ import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
                 0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverContent[data-state='open'][data-side='top'] {
-            animation-name: slideDownAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='right'] {
-            animation-name: slideLeftAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='bottom'] {
-            animation-name: slideUpAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='left'] {
-            animation-name: slideRightAndFade;
         }
 
         .PopoverArrow {
@@ -157,50 +140,6 @@ import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
             font-weight: bolder;
         }
 
-        @keyframes slideUpAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideRightAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        @keyframes slideDownAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideLeftAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
         /* =============== Params layout =============== */
 
         .ParamsContainer {
@@ -240,7 +179,7 @@ import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
                     (onHide)="onHide()"
                     rdxPopoverContent
                 >
-                    <div class="PopoverContent">
+                    <div class="PopoverContent" rdxPopoverContentAttributes>
                         <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>

--- a/packages/primitives/popover/stories/popover-events.components.ts
+++ b/packages/primitives/popover/stories/popover-events.components.ts
@@ -21,7 +21,7 @@ import { PopoverWithEventBaseComponent } from './popover-with-event-base.compone
     `,
     template: `
         <popover-with-event-base>
-            <div class="container" #eventsContainer>
+            <div class="container">
                 <ng-container rdxPopoverRoot>
                     <button class="reset IconButton" #triggerElement rdxPopoverTrigger>
                         <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />

--- a/packages/primitives/popover/stories/popover-initially-open.component.ts
+++ b/packages/primitives/popover/stories/popover-initially-open.component.ts
@@ -1,13 +1,13 @@
-import { Component, signal } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
-import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
+import { RdxPopoverModule } from '../index';
 import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
 import styles from './popover-styles.constants';
 import { PopoverWithEventBaseComponent } from './popover-with-event-base.component';
 
 @Component({
-    selector: 'rdx-popover-positioning',
+    selector: 'rdx-popover-initially-open',
     standalone: true,
     imports: [
         FormsModule,
@@ -19,49 +19,13 @@ import { PopoverWithEventBaseComponent } from './popover-with-event-base.compone
     styles: styles(),
     template: `
         <popover-with-event-base>
-            <div class="ParamsContainer">
-                Side:
-                <select [ngModel]="selectedSide()" (ngModelChange)="selectedSide.set($event)">
-                    <option [value]="sides.Top">{{ sides.Top }}</option>
-                    <option [value]="sides.Bottom">{{ sides.Bottom }}</option>
-                    <option [value]="sides.Left">{{ sides.Left }}</option>
-                    <option [value]="sides.Right">{{ sides.Right }}</option>
-                </select>
-                Align:
-                <select [ngModel]="selectedAlign()" (ngModelChange)="selectedAlign.set($event)">
-                    <option [value]="aligns.Center">{{ aligns.Center }}</option>
-                    <option [value]="aligns.Start">{{ aligns.Start }}</option>
-                    <option [value]="aligns.End">{{ aligns.End }}</option>
-                </select>
-                SideOffset:
-                <input [ngModel]="sideOffset()" (ngModelChange)="sideOffset.set($event)" type="number" />
-                AlignOffset:
-                <input [ngModel]="alignOffset()" (ngModelChange)="alignOffset.set($event)" type="number" />
-            </div>
-
-            <div class="ParamsContainer">
-                <input
-                    [ngModel]="disableAlternatePositions()"
-                    (ngModelChange)="disableAlternatePositions.set($event)"
-                    type="checkbox"
-                />
-                Alternate positions
-            </div>
-
             <div class="container">
-                <ng-container rdxPopoverRoot>
+                <ng-container [defaultOpen]="true" rdxPopoverRoot>
                     <button class="reset IconButton" rdxPopoverTrigger>
                         <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
                     </button>
 
-                    <ng-template
-                        [sideOffset]="sideOffset()"
-                        [alignOffset]="alignOffset()"
-                        [side]="selectedSide()"
-                        [align]="selectedAlign()"
-                        [disableAlternatePositions]="disableAlternatePositions()"
-                        rdxPopoverContent
-                    >
+                    <ng-template [sideOffset]="8" rdxPopoverContent>
                         <div class="PopoverContent" rdxPopoverContentAttributes>
                             <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
                                 <lucide-angular [img]="XIcon" size="16" style="display: flex" />
@@ -93,16 +57,7 @@ import { PopoverWithEventBaseComponent } from './popover-with-event-base.compone
         </popover-with-event-base>
     `
 })
-export class RdxPopoverPositioningComponent {
-    readonly selectedSide = signal(RdxPopoverSide.Top);
-    readonly selectedAlign = signal(RdxPopoverAlign.Center);
-    readonly sideOffset = signal(8);
-    readonly alignOffset = signal<number | undefined>(void 0);
-    readonly disableAlternatePositions = signal(false);
-
-    readonly sides = RdxPopoverSide;
-    readonly aligns = RdxPopoverAlign;
-
+export class RdxPopoverInitiallyOpenComponent {
     readonly MountainSnowIcon = MountainSnowIcon;
     readonly XIcon = X;
 }

--- a/packages/primitives/popover/stories/popover-multiple.component.ts
+++ b/packages/primitives/popover/stories/popover-multiple.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
-import { RdxPopoverModule } from '../index';
+import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
+import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
 
 @Component({
     selector: 'rdx-popover-multiple',
@@ -9,7 +10,8 @@ import { RdxPopoverModule } from '../index';
     imports: [
         FormsModule,
         RdxPopoverModule,
-        LucideAngularModule
+        LucideAngularModule,
+        RdxPopoverContentAttributesComponent
     ],
     styles: `
         .container {
@@ -34,9 +36,6 @@ import { RdxPopoverModule } from '../index';
             box-shadow:
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-            animation-duration: 400ms;
-            animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-            will-change: transform, opacity;
         }
 
         .PopoverContent:focus {
@@ -44,22 +43,6 @@ import { RdxPopoverModule } from '../index';
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
                 0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverContent[data-state='open'][data-side='top'] {
-            animation-name: slideDownAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='right'] {
-            animation-name: slideLeftAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='bottom'] {
-            animation-name: slideUpAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='left'] {
-            animation-name: slideRightAndFade;
         }
 
         .PopoverArrow {
@@ -147,50 +130,6 @@ import { RdxPopoverModule } from '../index';
             line-height: 19px;
             font-weight: 500;
         }
-
-        @keyframes slideUpAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideRightAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        @keyframes slideDownAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideLeftAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
     `,
     template: `
         <div class="container">
@@ -200,7 +139,7 @@ import { RdxPopoverModule } from '../index';
                 </button>
 
                 <ng-template rdxPopoverContent>
-                    <div class="PopoverContent">
+                    <div class="PopoverContent" rdxPopoverContentAttributes>
                         <button class="PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>
@@ -235,8 +174,14 @@ import { RdxPopoverModule } from '../index';
                     <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
                 </button>
 
-                <ng-template [sideOffset]="16" [alignOffset]="16" rdxPopoverContent>
-                    <div class="PopoverContent">
+                <ng-template
+                    [side]="RdxPopoverSide.Left"
+                    [align]="RdxPopoverAlign.Start"
+                    [sideOffset]="16"
+                    [alignOffset]="16"
+                    rdxPopoverContent
+                >
+                    <div class="PopoverContent" rdxPopoverContentAttributes>
                         <button class="PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>
@@ -271,8 +216,14 @@ import { RdxPopoverModule } from '../index';
                     <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
                 </button>
 
-                <ng-template [sideOffset]="60" [alignOffset]="60" rdxPopoverContent>
-                    <div class="PopoverContent">
+                <ng-template
+                    [side]="RdxPopoverSide.Right"
+                    [align]="RdxPopoverAlign.End"
+                    [sideOffset]="60"
+                    [alignOffset]="60"
+                    rdxPopoverContent
+                >
+                    <div class="PopoverContent" rdxPopoverContentAttributes>
                         <button class="PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>
@@ -305,4 +256,6 @@ import { RdxPopoverModule } from '../index';
 export class RdxPopoverMultipleComponent {
     readonly MountainSnowIcon = MountainSnowIcon;
     readonly XIcon = X;
+    readonly RdxPopoverSide = RdxPopoverSide;
+    readonly RdxPopoverAlign = RdxPopoverAlign;
 }

--- a/packages/primitives/popover/stories/popover-multiple.component.ts
+++ b/packages/primitives/popover/stories/popover-multiple.component.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
 import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
+import styles from './popover-styles.constants';
 
 @Component({
     selector: 'rdx-popover-multiple',
@@ -13,153 +14,36 @@ import { RdxPopoverContentAttributesComponent } from '../src/popover-content-att
         LucideAngularModule,
         RdxPopoverContentAttributesComponent
     ],
-    styles: `
-        .container {
-            height: 150px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
-
-        /* reset */
-        button,
-        fieldset,
-        input {
-            all: unset;
-        }
-
-        .PopoverContent {
-            border-radius: 4px;
-            padding: 20px;
-            width: 260px;
-            background-color: white;
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-        }
-
-        .PopoverContent:focus {
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
-                0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverArrow {
-            fill: white;
-        }
-
-        .PopoverClose {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 25px;
-            width: 25px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            position: absolute;
-            top: 5px;
-            right: 5px;
-        }
-
-        .PopoverClose:hover {
-            background-color: var(--violet-4);
-        }
-
-        .PopoverClose:focus {
-            box-shadow: 0 0 0 2px var(--violet-7);
-        }
-
-        .IconButton {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 35px;
-            width: 35px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            background-color: white;
-            box-shadow: 0 2px 10px var(--black-a7);
-        }
-
-        .IconButton:hover {
-            background-color: var(--violet-3);
-        }
-
-        .IconButton:focus {
-            box-shadow: 0 0 0 2px black;
-        }
-
-        .Fieldset {
-            display: flex;
-            gap: 20px;
-            align-items: center;
-        }
-
-        .Label {
-            font-size: 13px;
-            color: var(--violet-11);
-            width: 75px;
-        }
-
-        .Input {
-            width: 100%;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            flex: 1;
-            border-radius: 4px;
-            padding: 0 10px;
-            font-size: 13px;
-            line-height: 1;
-            color: var(--violet-11);
-            box-shadow: 0 0 0 1px var(--violet-7);
-            height: 25px;
-        }
-
-        .Input:focus {
-            box-shadow: 0 0 0 2px var(--violet-8);
-        }
-
-        .Text {
-            margin: 0;
-            color: var(--mauve-12);
-            font-size: 15px;
-            line-height: 19px;
-            font-weight: 500;
-        }
-    `,
+    styles: styles(),
     template: `
         <div class="container">
             <ng-container rdxPopoverRoot>
-                <button class="IconButton" rdxPopoverTrigger>
+                <button class="reset IconButton" rdxPopoverTrigger>
                     <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
                 </button>
 
                 <ng-template rdxPopoverContent>
                     <div class="PopoverContent" rdxPopoverContentAttributes>
-                        <button class="PopoverClose" rdxPopoverClose aria-label="Close">
+                        <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>
                         <div style="display: flex; flex-direction: column; gap: 10px">
                             <p class="Text" style="margin-bottom: 10px">Dimensions</p>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="width">Width</label>
-                                <input class="Input" id="width" value="100%" />
+                                <input class="reset Input" id="width" value="100%" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="maxWidth">Max. width</label>
-                                <input class="Input" id="maxWidth" value="300px" />
+                                <input class="reset Input" id="maxWidth" value="300px" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="height">Height</label>
-                                <input class="Input" id="height" value="25px" />
+                                <input class="reset Input" id="height" value="25px" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="maxHeight">Max. height</label>
-                                <input class="Input" id="maxHeight" value="none" />
+                                <input class="reset Input" id="maxHeight" value="none" />
                             </fieldset>
                         </div>
                         <div class="PopoverArrow" rdxPopoverArrow></div>
@@ -170,7 +54,7 @@ import { RdxPopoverContentAttributesComponent } from '../src/popover-content-att
 
         <div class="container">
             <ng-container rdxPopoverRoot>
-                <button class="IconButton" rdxPopoverTrigger>
+                <button class="reset IconButton" rdxPopoverTrigger>
                     <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
                 </button>
 
@@ -182,26 +66,26 @@ import { RdxPopoverContentAttributesComponent } from '../src/popover-content-att
                     rdxPopoverContent
                 >
                     <div class="PopoverContent" rdxPopoverContentAttributes>
-                        <button class="PopoverClose" rdxPopoverClose aria-label="Close">
+                        <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>
                         <div style="display: flex; flex-direction: column; gap: 10px">
                             <p class="Text" style="margin-bottom: 10px">Dimensions</p>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="width">Width</label>
-                                <input class="Input" id="width" value="100%" />
+                                <input class="reset Input" id="width" value="100%" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="maxWidth">Max. width</label>
-                                <input class="Input" id="maxWidth" value="300px" />
+                                <input class="reset Input" id="maxWidth" value="300px" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="height">Height</label>
-                                <input class="Input" id="height" value="25px" />
+                                <input class="reset Input" id="height" value="25px" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="maxHeight">Max. height</label>
-                                <input class="Input" id="maxHeight" value="none" />
+                                <input class="reset Input" id="maxHeight" value="none" />
                             </fieldset>
                         </div>
                         <div class="PopoverArrow" rdxPopoverArrow></div>
@@ -212,7 +96,7 @@ import { RdxPopoverContentAttributesComponent } from '../src/popover-content-att
 
         <div class="container">
             <ng-container rdxPopoverRoot>
-                <button class="IconButton" rdxPopoverTrigger>
+                <button class="reset IconButton" rdxPopoverTrigger>
                     <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
                 </button>
 
@@ -224,26 +108,26 @@ import { RdxPopoverContentAttributesComponent } from '../src/popover-content-att
                     rdxPopoverContent
                 >
                     <div class="PopoverContent" rdxPopoverContentAttributes>
-                        <button class="PopoverClose" rdxPopoverClose aria-label="Close">
+                        <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>
                         <div style="display: flex; flex-direction: column; gap: 10px">
                             <p class="Text" style="margin-bottom: 10px">Dimensions</p>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="width">Width</label>
-                                <input class="Input" id="width" value="100%" />
+                                <input class="reset Input" id="width" value="100%" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="maxWidth">Max. width</label>
-                                <input class="Input" id="maxWidth" value="300px" />
+                                <input class="reset Input" id="maxWidth" value="300px" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="height">Height</label>
-                                <input class="Input" id="height" value="25px" />
+                                <input class="reset Input" id="height" value="25px" />
                             </fieldset>
-                            <fieldset class="Fieldset">
+                            <fieldset class="reset Fieldset">
                                 <label class="Label" for="maxHeight">Max. height</label>
-                                <input class="Input" id="maxHeight" value="none" />
+                                <input class="reset Input" id="maxHeight" value="none" />
                             </fieldset>
                         </div>
                         <div class="PopoverArrow" rdxPopoverArrow></div>

--- a/packages/primitives/popover/stories/popover-positioning.component.ts
+++ b/packages/primitives/popover/stories/popover-positioning.component.ts
@@ -1,9 +1,10 @@
 import { Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
-import { RdxPopoverModule } from '../index';
+import { RdxPopoverAlign, RdxPopoverModule, RdxPopoverSide } from '../index';
 import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
-import { RdxPopoverAlign, RdxPopoverSide } from '../src/popover.types';
+import styles from './popover-styles.constants';
+import { PopoverWithEventBaseComponent } from './popover-with-event-base.component';
 
 @Component({
     selector: 'rdx-popover-positioning',
@@ -12,214 +13,96 @@ import { RdxPopoverAlign, RdxPopoverSide } from '../src/popover.types';
         FormsModule,
         RdxPopoverModule,
         LucideAngularModule,
-        RdxPopoverContentAttributesComponent
+        RdxPopoverContentAttributesComponent,
+        PopoverWithEventBaseComponent
     ],
-    styles: `
-        .container {
-            height: 150px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
-
-        /* reset */
-        .reset {
-            all: unset;
-        }
-
-        .PopoverContent {
-            border-radius: 4px;
-            padding: 20px;
-            width: 260px;
-            background-color: white;
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-        }
-
-        .PopoverContent:focus {
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
-                0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverArrow {
-            fill: white;
-        }
-
-        .PopoverClose {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 25px;
-            width: 25px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            position: absolute;
-            top: 5px;
-            right: 5px;
-        }
-
-        .PopoverClose:hover {
-            background-color: var(--violet-4);
-        }
-
-        .PopoverClose:focus {
-            box-shadow: 0 0 0 2px var(--violet-7);
-        }
-
-        .IconButton {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 35px;
-            width: 35px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            background-color: white;
-            box-shadow: 0 2px 10px var(--black-a7);
-        }
-
-        .IconButton:hover {
-            background-color: var(--violet-3);
-        }
-
-        .IconButton:focus {
-            box-shadow: 0 0 0 2px black;
-        }
-
-        .Fieldset {
-            display: flex;
-            gap: 20px;
-            align-items: center;
-        }
-
-        .Label {
-            font-size: 13px;
-            color: var(--violet-11);
-            width: 75px;
-        }
-
-        .Input {
-            width: 100%;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            flex: 1;
-            border-radius: 4px;
-            padding: 0 10px;
-            font-size: 13px;
-            line-height: 1;
-            color: var(--violet-11);
-            box-shadow: 0 0 0 1px var(--violet-7);
-            height: 25px;
-        }
-
-        .Input:focus {
-            box-shadow: 0 0 0 2px var(--violet-8);
-        }
-
-        .Text {
-            margin: 0;
-            color: var(--mauve-12);
-            font-size: 15px;
-            line-height: 19px;
-            font-weight: 500;
-        }
-
-        /* =============== Params layout =============== */
-
-        .ParamsContainer {
-            display: flex;
-            column-gap: 8px;
-            color: var(--white-a12);
-            margin-bottom: 32px;
-        }
-    `,
+    styles: styles(),
     template: `
-        <div class="ParamsContainer">
-            Side:
-            <select [ngModel]="selectedSide()" (ngModelChange)="selectedSide.set($event)">
-                <option [value]="sides.Top">{{ sides.Top }}</option>
-                <option [value]="sides.Bottom">{{ sides.Bottom }}</option>
-                <option [value]="sides.Left">{{ sides.Left }}</option>
-                <option [value]="sides.Right">{{ sides.Right }}</option>
-            </select>
-            Align:
-            <select [ngModel]="selectedAlign()" (ngModelChange)="selectedAlign.set($event)">
-                <option [value]="aligns.Center">{{ aligns.Center }}</option>
-                <option [value]="aligns.Start">{{ aligns.Start }}</option>
-                <option [value]="aligns.End">{{ aligns.End }}</option>
-            </select>
-            SideOffset:
-            <input [ngModel]="sideOffset()" (ngModelChange)="sideOffset.set($event)" type="number" />
-            AlignOffset:
-            <input [ngModel]="alignOffset()" (ngModelChange)="alignOffset.set($event)" type="number" />
-            Alternate positions:
-            <input
-                [ngModel]="disableAlternatePositions()"
-                (ngModelChange)="disableAlternatePositions.set($event)"
-                type="checkbox"
-            />
-        </div>
+        <popover-with-event-base>
+            <div class="ParamsContainer">
+                Side:
+                <select [ngModel]="selectedSide()" (ngModelChange)="selectedSide.set($event)">
+                    <option [value]="sides.Top">{{ sides.Top }}</option>
+                    <option [value]="sides.Bottom">{{ sides.Bottom }}</option>
+                    <option [value]="sides.Left">{{ sides.Left }}</option>
+                    <option [value]="sides.Right">{{ sides.Right }}</option>
+                </select>
+                Align:
+                <select [ngModel]="selectedAlign()" (ngModelChange)="selectedAlign.set($event)">
+                    <option [value]="aligns.Center">{{ aligns.Center }}</option>
+                    <option [value]="aligns.Start">{{ aligns.Start }}</option>
+                    <option [value]="aligns.End">{{ aligns.End }}</option>
+                </select>
+                SideOffset:
+                <input [ngModel]="sideOffset()" (ngModelChange)="sideOffset.set($event)" type="number" />
+                AlignOffset:
+                <input [ngModel]="alignOffset()" (ngModelChange)="alignOffset.set($event)" type="number" />
+            </div>
 
-        <div class="container">
-            <ng-container rdxPopoverRoot>
-                <button class="IconButton reset" rdxPopoverTrigger>
-                    <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
-                </button>
+            <div class="ParamsContainer">
+                Alternate positions:
+                <input
+                    [ngModel]="disableAlternatePositions()"
+                    (ngModelChange)="disableAlternatePositions.set($event)"
+                    type="checkbox"
+                />
+            </div>
 
-                <ng-template
-                    [sideOffset]="sideOffset()"
-                    [alignOffset]="alignOffset()"
-                    [side]="selectedSide()"
-                    [align]="selectedAlign()"
-                    [disableAlternatePositions]="disableAlternatePositions()"
-                    rdxPopoverContent
-                >
-                    <div class="PopoverContent" rdxPopoverContentAttributes>
-                        <button class="PopoverClose reset" rdxPopoverClose aria-label="Close">
-                            <lucide-angular [img]="XIcon" size="16" style="display: flex" />
-                        </button>
-                        <div style="display: flex; flex-direction: column; gap: 10px">
-                            <p class="Text" style="margin-bottom: 10px">Dimensions</p>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="width">Width</label>
-                                <input class="reset Input" id="width" value="100%" />
-                            </fieldset>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="maxWidth">Max. width</label>
-                                <input class="reset Input" id="maxWidth" value="300px" />
-                            </fieldset>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="height">Height</label>
-                                <input class="reset Input" id="height" value="25px" />
-                            </fieldset>
-                            <fieldset class="reset Fieldset">
-                                <label class="Label" for="maxHeight">Max. height</label>
-                                <input class="reset Input" id="maxHeight" value="none" />
-                            </fieldset>
+            <div class="container">
+                <ng-container rdxPopoverRoot>
+                    <button class="reset IconButton" rdxPopoverTrigger>
+                        <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
+                    </button>
+
+                    <ng-template
+                        [sideOffset]="sideOffset()"
+                        [alignOffset]="alignOffset()"
+                        [side]="selectedSide()"
+                        [align]="selectedAlign()"
+                        [disableAlternatePositions]="disableAlternatePositions()"
+                        rdxPopoverContent
+                    >
+                        <div class="PopoverContent" rdxPopoverContentAttributes>
+                            <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
+                                <lucide-angular [img]="XIcon" size="16" style="display: flex" />
+                            </button>
+                            <div style="display: flex; flex-direction: column; gap: 10px">
+                                <p class="Text" style="margin-bottom: 10px">Dimensions</p>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="width">Width</label>
+                                    <input class="reset Input" id="width" value="100%" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxWidth">Max. width</label>
+                                    <input class="reset Input" id="maxWidth" value="300px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="height">Height</label>
+                                    <input class="reset Input" id="height" value="25px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxHeight">Max. height</label>
+                                    <input class="reset Input" id="maxHeight" value="none" />
+                                </fieldset>
+                            </div>
+                            <div class="PopoverArrow" rdxPopoverArrow></div>
                         </div>
-                        <div class="PopoverArrow" rdxPopoverArrow></div>
-                    </div>
-                </ng-template>
-            </ng-container>
-        </div>
+                    </ng-template>
+                </ng-container>
+            </div>
+        </popover-with-event-base>
     `
 })
 export class RdxPopoverPositioningComponent {
-    readonly MountainSnowIcon = MountainSnowIcon;
-    readonly XIcon = X;
-
-    selectedSide = signal(RdxPopoverSide.Top);
-    selectedAlign = signal(RdxPopoverAlign.Center);
-    sideOffset = signal(8);
-    alignOffset = signal<number | undefined>(void 0);
-    disableAlternatePositions = signal(false);
+    readonly selectedSide = signal(RdxPopoverSide.Top);
+    readonly selectedAlign = signal(RdxPopoverAlign.Center);
+    readonly sideOffset = signal(8);
+    readonly alignOffset = signal<number | undefined>(void 0);
+    readonly disableAlternatePositions = signal(false);
 
     readonly sides = RdxPopoverSide;
     readonly aligns = RdxPopoverAlign;
+
+    readonly MountainSnowIcon = MountainSnowIcon;
+    readonly XIcon = X;
 }

--- a/packages/primitives/popover/stories/popover-positioning.component.ts
+++ b/packages/primitives/popover/stories/popover-positioning.component.ts
@@ -2,6 +2,7 @@ import { Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverModule } from '../index';
+import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
 import { RdxPopoverAlign, RdxPopoverSide } from '../src/popover.types';
 
 @Component({
@@ -10,7 +11,8 @@ import { RdxPopoverAlign, RdxPopoverSide } from '../src/popover.types';
     imports: [
         FormsModule,
         RdxPopoverModule,
-        LucideAngularModule
+        LucideAngularModule,
+        RdxPopoverContentAttributesComponent
     ],
     styles: `
         .container {
@@ -33,9 +35,6 @@ import { RdxPopoverAlign, RdxPopoverSide } from '../src/popover.types';
             box-shadow:
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-            animation-duration: 400ms;
-            animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-            will-change: transform, opacity;
         }
 
         .PopoverContent:focus {
@@ -43,22 +42,6 @@ import { RdxPopoverAlign, RdxPopoverSide } from '../src/popover.types';
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
                 0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverContent[data-state='open'][data-side='top'] {
-            animation-name: slideDownAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='right'] {
-            animation-name: slideLeftAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='bottom'] {
-            animation-name: slideUpAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='left'] {
-            animation-name: slideRightAndFade;
         }
 
         .PopoverArrow {
@@ -147,50 +130,6 @@ import { RdxPopoverAlign, RdxPopoverSide } from '../src/popover.types';
             font-weight: 500;
         }
 
-        @keyframes slideUpAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideRightAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        @keyframes slideDownAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideLeftAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
         /* =============== Params layout =============== */
 
         .ParamsContainer {
@@ -241,7 +180,7 @@ import { RdxPopoverAlign, RdxPopoverSide } from '../src/popover.types';
                     [disableAlternatePositions]="disableAlternatePositions()"
                     rdxPopoverContent
                 >
-                    <div class="PopoverContent">
+                    <div class="PopoverContent" rdxPopoverContentAttributes>
                         <button class="PopoverClose reset" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>
@@ -278,7 +217,7 @@ export class RdxPopoverPositioningComponent {
     selectedSide = signal(RdxPopoverSide.Top);
     selectedAlign = signal(RdxPopoverAlign.Center);
     sideOffset = signal(8);
-    alignOffset = signal(8);
+    alignOffset = signal<number | undefined>(void 0);
     disableAlternatePositions = signal(false);
 
     readonly sides = RdxPopoverSide;

--- a/packages/primitives/popover/stories/popover-styles.constants.ts
+++ b/packages/primitives/popover/stories/popover-styles.constants.ts
@@ -161,7 +161,7 @@ const params = `
     display: flex;
     column-gap: 8px;
     color: var(--white-a12);
-    margin-bottom: 32px;
+    padding-bottom: 32px;
 }
 `;
 
@@ -184,7 +184,11 @@ function styles(withAnimations = false, withEvents = false, withParams = true) {
     font-size: 22px;
     line-height: 26px;
     font-weight: bolder;
-    margin: 0 0 34px 16px;
+    margin: 12px 0 34px 16px;
+    padding-top: 12px;
+    &:not(:first-child) {
+        border-top: 2px solid var(--gray-a8);
+    }
 }
 
 .PopoverContent {

--- a/packages/primitives/popover/stories/popover-styles.constants.ts
+++ b/packages/primitives/popover/stories/popover-styles.constants.ts
@@ -179,6 +179,14 @@ function styles(withAnimations = false, withEvents = false, withParams = true) {
     all: unset;
 }
 
+.ExampleSubtitle {
+    color: var(--white-a12);
+    font-size: 22px;
+    line-height: 26px;
+    font-weight: bolder;
+    margin: 0 0 34px 16px;
+}
+
 .PopoverContent {
     border-radius: 4px;
     padding: 20px;

--- a/packages/primitives/popover/stories/popover-styles.constants.ts
+++ b/packages/primitives/popover/stories/popover-styles.constants.ts
@@ -1,0 +1,311 @@
+const appliedAnimations = `
+.PopoverContent[data-state='open'][data-side='top'] {
+    animation-name: rdxSlideDownAndFade;
+}
+
+.PopoverContent[data-state='open'][data-side='right'] {
+    animation-name: rdxSlideLeftAndFade;
+}
+
+.PopoverContent[data-state='open'][data-side='bottom'] {
+    animation-name: rdxSlideUpAndFade;
+}
+
+.PopoverContent[data-state='open'][data-side='left'] {
+    animation-name: rdxSlideRightAndFade;
+}
+
+.PopoverContent[data-state='closed'][data-side='top'] {
+    animation-name: rdxSlideDownAndFadeReverse;
+}
+
+.PopoverContent[data-state='closed'][data-side='right'] {
+    animation-name: rdxSlideLeftAndFadeReverse;
+}
+
+.PopoverContent[data-state='closed'][data-side='bottom'] {
+    animation-name: rdxSlideUpAndFadeReverse;
+}
+
+.PopoverContent[data-state='closed'][data-side='left'] {
+    animation-name: rdxSlideRightAndFadeReverse;
+}
+`;
+
+const animationParams = `
+.PopoverContent {
+    animation-duration: 400ms;
+    animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+    will-change: transform, opacity;
+}
+`;
+
+const animationDefs = `
+/* Open animations */
+
+@keyframes rdxSlideUpAndFade {
+    from {
+        opacity: 0;
+        transform: translateY(2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes rdxSlideRightAndFade {
+    from {
+        opacity: 0;
+        transform: translateX(-2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes rdxSlideDownAndFade {
+    from {
+        opacity: 0;
+        transform: translateY(-2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes rdxSlideLeftAndFade {
+    from {
+        opacity: 0;
+        transform: translateX(2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+/* Close animations */
+
+@keyframes rdxSlideUpAndFadeReverse {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(2px);
+    }
+}
+
+@keyframes rdxSlideRightAndFadeReverse {
+    from {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateX(-2px);
+    }
+}
+
+@keyframes rdxSlideDownAndFadeReverse {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(-2px);
+    }
+}
+
+@keyframes rdxSlideLeftAndFadeReverse {
+    from {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateX(2px);
+    }
+}
+`;
+
+const events = `
+/* =============== Event messages =============== */
+
+.MessagesContainer {
+    padding: 20px;
+}
+
+.Message {
+    color: var(--white-a12);
+    font-size: 15px;
+    line-height: 19px;
+    font-weight: bolder;
+}
+
+.MessageId {
+    font-size: 75%;
+    font-weight: light;
+}
+`;
+
+const params = `
+/* =============== Params layout =============== */
+
+.ParamsContainer {
+    display: flex;
+    column-gap: 8px;
+    color: var(--white-a12);
+    margin-bottom: 32px;
+}
+`;
+
+function styles(withAnimations = false, withEvents = false, withParams = true) {
+    return `
+.container {
+    height: 450px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* reset */
+.reset {
+    all: unset;
+}
+
+.PopoverContent {
+    border-radius: 4px;
+    padding: 20px;
+    width: 260px;
+    background-color: white;
+    box-shadow:
+        hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
+        hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
+}
+
+${withAnimations ? animationParams : ''}
+
+${withAnimations ? appliedAnimations : ''}
+
+.PopoverContent:focus {
+    box-shadow:
+        hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
+        hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
+        0 0 0 2px var(--violet-7);
+}
+
+.PopoverArrow {
+    fill: white;
+}
+
+.PopoverClose {
+    font-family: inherit;
+    border-radius: 100%;
+    height: 25px;
+    width: 25px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--violet-11);
+    position: absolute;
+    top: 5px;
+    right: 5px;
+}
+
+.PopoverClose:hover {
+    background-color: var(--violet-4);
+}
+
+.PopoverClose:focus {
+    box-shadow: 0 0 0 2px var(--violet-7);
+}
+
+.IconButton {
+    font-family: inherit;
+    border-radius: 100%;
+    height: 35px;
+    width: 35px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--violet-11);
+    background-color: white;
+    box-shadow: 0 2px 10px var(--black-a7);
+}
+
+.IconButton:hover {
+    background-color: var(--violet-3);
+}
+
+.IconButton:focus {
+    box-shadow: 0 0 0 2px black;
+}
+
+.Fieldset {
+    display: flex;
+    gap: 20px;
+    align-items: center;
+}
+
+.Label {
+    font-size: 13px;
+    color: var(--violet-11);
+    width: 75px;
+}
+
+.Input {
+    width: 100%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    border-radius: 4px;
+    padding: 0 10px;
+    font-size: 13px;
+    line-height: 1;
+    color: var(--violet-11);
+    box-shadow: 0 0 0 1px var(--violet-7);
+    height: 25px;
+}
+
+.Input:focus {
+    box-shadow: 0 0 0 2px var(--violet-8);
+}
+
+.Text {
+    margin: 0;
+    color: var(--mauve-12);
+    font-size: 15px;
+    line-height: 19px;
+    font-weight: 500;
+}
+
+${withAnimations ? animationDefs : ''}
+
+${withParams ? params : ''}
+
+${withEvents ? events : ''}
+`;
+}
+
+export const animationStylesOnly = `
+${animationParams}
+
+${appliedAnimations}
+
+${animationDefs}
+`;
+
+export const paramsAndEventsOnly = `
+${params}
+
+${events}
+`;
+
+export default styles;

--- a/packages/primitives/popover/stories/popover-styles.constants.ts
+++ b/packages/primitives/popover/stories/popover-styles.constants.ts
@@ -41,7 +41,7 @@ const animationParams = `
 `;
 
 const animationDefs = `
-/* Open animations */
+/* Opening animations */
 
 @keyframes rdxSlideUpAndFade {
     from {
@@ -87,7 +87,7 @@ const animationDefs = `
     }
 }
 
-/* Close animations */
+/* Closing animations */
 
 @keyframes rdxSlideUpAndFadeReverse {
     from {

--- a/packages/primitives/popover/stories/popover-triggering.component.ts
+++ b/packages/primitives/popover/stories/popover-triggering.component.ts
@@ -2,6 +2,7 @@ import { Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverModule } from '../index';
+import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
 
 @Component({
     selector: 'rdx-popover-triggering',
@@ -9,7 +10,8 @@ import { RdxPopoverModule } from '../index';
     imports: [
         FormsModule,
         RdxPopoverModule,
-        LucideAngularModule
+        LucideAngularModule,
+        RdxPopoverContentAttributesComponent
     ],
     styles: `
         .container {
@@ -34,9 +36,6 @@ import { RdxPopoverModule } from '../index';
             box-shadow:
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-            animation-duration: 400ms;
-            animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-            will-change: transform, opacity;
         }
 
         .PopoverContent:focus {
@@ -44,22 +43,6 @@ import { RdxPopoverModule } from '../index';
                 hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
                 hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
                 0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverContent[data-state='open'][data-side='top'] {
-            animation-name: slideDownAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='right'] {
-            animation-name: slideLeftAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='bottom'] {
-            animation-name: slideUpAndFade;
-        }
-
-        .PopoverContent[data-state='open'][data-side='left'] {
-            animation-name: slideRightAndFade;
         }
 
         .PopoverArrow {
@@ -148,50 +131,6 @@ import { RdxPopoverModule } from '../index';
             font-weight: 500;
         }
 
-        @keyframes slideUpAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideRightAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
-        @keyframes slideDownAndFade {
-            from {
-                opacity: 0;
-                transform: translateY(-2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateY(0);
-            }
-        }
-
-        @keyframes slideLeftAndFade {
-            from {
-                opacity: 0;
-                transform: translateX(2px);
-            }
-            to {
-                opacity: 1;
-                transform: translateX(0);
-            }
-        }
-
         /* =============== Trigger layout =============== */
 
         .TriggerContainer {
@@ -222,7 +161,7 @@ import { RdxPopoverModule } from '../index';
                 </button>
 
                 <ng-template [sideOffset]="8" rdxPopoverContent>
-                    <div class="PopoverContent">
+                    <div class="PopoverContent" rdxPopoverContentAttributes>
                         <button class="PopoverClose" rdxPopoverClose aria-label="Close">
                             <lucide-angular [img]="XIcon" size="16" style="display: flex" />
                         </button>

--- a/packages/primitives/popover/stories/popover-triggering.component.ts
+++ b/packages/primitives/popover/stories/popover-triggering.component.ts
@@ -18,19 +18,92 @@ import { PopoverWithEventBaseComponent } from './popover-with-event-base.compone
     ],
     styles: styles(),
     template: `
+        <p class="ExampleSubtitle">Initially closed</p>
         <popover-with-event-base>
             <div class="ParamsContainer">
-                <button (click)="trigger()" type="button">Open: {{ isOpen() }}</button>
-                <span>onOpenChange count: {{ counter() }}</span>
+                <button (click)="triggerOpenFalse()" type="button">Open: {{ isOpenFalse() }}</button>
+                onOpenChange count: {{ counterOpenFalse() }}
+            </div>
+
+            <div class="ParamsContainer">
+                <input
+                    [ngModel]="externalControlFalse()"
+                    (ngModelChange)="externalControlFalse.set($event)"
+                    type="checkbox"
+                />
+                External control
             </div>
 
             <div class="container">
-                <ng-container [open]="isOpen()" (onOpenChange)="count()" rdxPopoverRoot>
+                <ng-container [open]="isOpenFalse()" [externalControl]="externalControlFalse()" rdxPopoverRoot>
                     <button class="reset IconButton" rdxPopoverTrigger>
                         <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
                     </button>
 
-                    <ng-template [sideOffset]="8" rdxPopoverContent>
+                    <ng-template
+                        [sideOffset]="8"
+                        (onOpen)="countOpenFalse()"
+                        (onClosed)="countOpenFalse()"
+                        rdxPopoverContent
+                    >
+                        <div class="PopoverContent" rdxPopoverContentAttributes>
+                            <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
+                                <lucide-angular [img]="XIcon" size="16" style="display: flex" />
+                            </button>
+                            <div style="display: flex; flex-direction: column; gap: 10px">
+                                <p class="Text" style="margin-bottom: 10px">Dimensions</p>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="width">Width</label>
+                                    <input class="reset Input" id="width" value="100%" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxWidth">Max. width</label>
+                                    <input class="reset Input" id="maxWidth" value="300px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="height">Height</label>
+                                    <input class="reset Input" id="height" value="25px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxHeight">Max. height</label>
+                                    <input class="reset Input" id="maxHeight" value="none" />
+                                </fieldset>
+                            </div>
+                            <div class="PopoverArrow" rdxPopoverArrow></div>
+                        </div>
+                    </ng-template>
+                </ng-container>
+            </div>
+        </popover-with-event-base>
+
+        <p class="ExampleSubtitle">Initially open</p>
+        <popover-with-event-base>
+            <div class="ParamsContainer">
+                <button (click)="triggerOpenTrue()" type="button">Open: {{ isOpenTrue() }}</button>
+                <span>onOpenChange count: {{ counterOpenTrue() }}</span>
+            </div>
+
+            <div class="ParamsContainer">
+                <input
+                    [ngModel]="externalControlTrue()"
+                    (ngModelChange)="externalControlTrue.set($event)"
+                    type="checkbox"
+                />
+                External control
+            </div>
+
+            <div class="container">
+                <ng-container [open]="isOpenTrue()" [externalControl]="externalControlTrue()" rdxPopoverRoot>
+                    <button class="reset IconButton" rdxPopoverTrigger>
+                        <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
+                    </button>
+
+                    <ng-template
+                        [sideOffset]="8"
+                        (onOpen)="countOpenTrue()"
+                        (onClosed)="countOpenTrue()"
+                        rdxPopoverContent
+                    >
                         <div class="PopoverContent" rdxPopoverContentAttributes>
                             <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
                                 <lucide-angular [img]="XIcon" size="16" style="display: flex" />
@@ -66,15 +139,27 @@ export class RdxPopoverTriggeringComponent {
     readonly MountainSnowIcon = MountainSnowIcon;
     readonly XIcon = X;
 
-    isOpen = signal(false);
+    isOpenFalse = signal(false);
+    counterOpenFalse = signal(0);
+    externalControlFalse = signal(true);
 
-    counter = signal(0);
+    isOpenTrue = signal(true);
+    counterOpenTrue = signal(0);
+    externalControlTrue = signal(true);
 
-    trigger(): void {
-        this.isOpen.update((value) => !value);
+    triggerOpenFalse(): void {
+        this.isOpenFalse.update((value) => !value);
     }
 
-    count(): void {
-        this.counter.update((value) => value + 1);
+    countOpenFalse(): void {
+        this.counterOpenFalse.update((value) => value + 1);
+    }
+
+    triggerOpenTrue(): void {
+        this.isOpenTrue.update((value) => !value);
+    }
+
+    countOpenTrue(): void {
+        this.counterOpenTrue.update((value) => value + 1);
     }
 }

--- a/packages/primitives/popover/stories/popover-triggering.component.ts
+++ b/packages/primitives/popover/stories/popover-triggering.component.ts
@@ -3,6 +3,8 @@ import { FormsModule } from '@angular/forms';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverModule } from '../index';
 import { RdxPopoverContentAttributesComponent } from '../src/popover-content-attributes.component';
+import styles from './popover-styles.constants';
+import { PopoverWithEventBaseComponent } from './popover-with-event-base.component';
 
 @Component({
     selector: 'rdx-popover-triggering',
@@ -11,184 +13,53 @@ import { RdxPopoverContentAttributesComponent } from '../src/popover-content-att
         FormsModule,
         RdxPopoverModule,
         LucideAngularModule,
-        RdxPopoverContentAttributesComponent
+        RdxPopoverContentAttributesComponent,
+        PopoverWithEventBaseComponent
     ],
-    styles: `
-        .container {
-            height: 150px;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
-
-        /* reset */
-        button,
-        fieldset,
-        input {
-            all: unset;
-        }
-
-        .PopoverContent {
-            border-radius: 4px;
-            padding: 20px;
-            width: 260px;
-            background-color: white;
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
-        }
-
-        .PopoverContent:focus {
-            box-shadow:
-                hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
-                hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
-                0 0 0 2px var(--violet-7);
-        }
-
-        .PopoverArrow {
-            fill: white;
-        }
-
-        .PopoverClose {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 25px;
-            width: 25px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            position: absolute;
-            top: 5px;
-            right: 5px;
-        }
-
-        .PopoverClose:hover {
-            background-color: var(--violet-4);
-        }
-
-        .PopoverClose:focus {
-            box-shadow: 0 0 0 2px var(--violet-7);
-        }
-
-        .IconButton {
-            font-family: inherit;
-            border-radius: 100%;
-            height: 35px;
-            width: 35px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            color: var(--violet-11);
-            background-color: white;
-            box-shadow: 0 2px 10px var(--black-a7);
-        }
-
-        .IconButton:hover {
-            background-color: var(--violet-3);
-        }
-
-        .IconButton:focus {
-            box-shadow: 0 0 0 2px black;
-        }
-
-        .Fieldset {
-            display: flex;
-            gap: 20px;
-            align-items: center;
-        }
-
-        .Label {
-            font-size: 13px;
-            color: var(--violet-11);
-            width: 75px;
-        }
-
-        .Input {
-            width: 100%;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            flex: 1;
-            border-radius: 4px;
-            padding: 0 10px;
-            font-size: 13px;
-            line-height: 1;
-            color: var(--violet-11);
-            box-shadow: 0 0 0 1px var(--violet-7);
-            height: 25px;
-        }
-
-        .Input:focus {
-            box-shadow: 0 0 0 2px var(--violet-8);
-        }
-
-        .Text {
-            margin: 0;
-            color: var(--mauve-12);
-            font-size: 15px;
-            line-height: 19px;
-            font-weight: 500;
-        }
-
-        /* =============== Trigger layout =============== */
-
-        .TriggerContainer {
-            display: flex;
-            column-gap: 8px;
-            color: var(--white-a12);
-            margin-bottom: 32px;
-            align-items: baseline;
-
-            button {
-                color: var(--violet-11);
-                background-color: white;
-                box-shadow: 0 2px 10px var(--black-a7);
-                padding: 4px 8px;
-                border-radius: 4px;
-            }
-        }
-    `,
+    styles: styles(),
     template: `
-        <div class="TriggerContainer">
-            <button (click)="trigger()" type="button">Open: {{ isOpen() }}</button>
-            <span>onOpenChange count: {{ counter() }}</span>
-        </div>
-        <div class="container">
-            <ng-container [open]="isOpen()" (onOpenChange)="count()" rdxPopoverRoot>
-                <button class="IconButton" rdxPopoverTrigger>
-                    <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
-                </button>
+        <popover-with-event-base>
+            <div class="ParamsContainer">
+                <button (click)="trigger()" type="button">Open: {{ isOpen() }}</button>
+                <span>onOpenChange count: {{ counter() }}</span>
+            </div>
 
-                <ng-template [sideOffset]="8" rdxPopoverContent>
-                    <div class="PopoverContent" rdxPopoverContentAttributes>
-                        <button class="PopoverClose" rdxPopoverClose aria-label="Close">
-                            <lucide-angular [img]="XIcon" size="16" style="display: flex" />
-                        </button>
-                        <div style="display: flex; flex-direction: column; gap: 10px">
-                            <p class="Text" style="margin-bottom: 10px">Dimensions</p>
-                            <fieldset class="Fieldset">
-                                <label class="Label" for="width">Width</label>
-                                <input class="Input" id="width" value="100%" />
-                            </fieldset>
-                            <fieldset class="Fieldset">
-                                <label class="Label" for="maxWidth">Max. width</label>
-                                <input class="Input" id="maxWidth" value="300px" />
-                            </fieldset>
-                            <fieldset class="Fieldset">
-                                <label class="Label" for="height">Height</label>
-                                <input class="Input" id="height" value="25px" />
-                            </fieldset>
-                            <fieldset class="Fieldset">
-                                <label class="Label" for="maxHeight">Max. height</label>
-                                <input class="Input" id="maxHeight" value="none" />
-                            </fieldset>
+            <div class="container">
+                <ng-container [open]="isOpen()" (onOpenChange)="count()" rdxPopoverRoot>
+                    <button class="reset IconButton" rdxPopoverTrigger>
+                        <lucide-angular [img]="MountainSnowIcon" size="16" style="display: flex" />
+                    </button>
+
+                    <ng-template [sideOffset]="8" rdxPopoverContent>
+                        <div class="PopoverContent" rdxPopoverContentAttributes>
+                            <button class="reset PopoverClose" rdxPopoverClose aria-label="Close">
+                                <lucide-angular [img]="XIcon" size="16" style="display: flex" />
+                            </button>
+                            <div style="display: flex; flex-direction: column; gap: 10px">
+                                <p class="Text" style="margin-bottom: 10px">Dimensions</p>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="width">Width</label>
+                                    <input class="reset Input" id="width" value="100%" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxWidth">Max. width</label>
+                                    <input class="reset Input" id="maxWidth" value="300px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="height">Height</label>
+                                    <input class="reset Input" id="height" value="25px" />
+                                </fieldset>
+                                <fieldset class="reset Fieldset">
+                                    <label class="Label" for="maxHeight">Max. height</label>
+                                    <input class="reset Input" id="maxHeight" value="none" />
+                                </fieldset>
+                            </div>
+                            <div class="PopoverArrow" rdxPopoverArrow></div>
                         </div>
-                        <div class="PopoverArrow" rdxPopoverArrow></div>
-                    </div>
-                </ng-template>
-            </ng-container>
-        </div>
+                    </ng-template>
+                </ng-container>
+            </div>
+        </popover-with-event-base>
     `
 })
 export class RdxPopoverTriggeringComponent {

--- a/packages/primitives/popover/stories/popover-with-event-base.component.ts
+++ b/packages/primitives/popover/stories/popover-with-event-base.component.ts
@@ -121,7 +121,6 @@ export class PopoverWithEventBaseComponent implements AfterContentInit {
     };
 
     private onOutsideClick = (event: MouseEvent) => {
-        console.log('onOutsideClick', event);
         if (
             !event.target ||
             (!this.inContainers(event.target as HTMLElement) && !this.inParamsContainers(event.target as HTMLElement))

--- a/packages/primitives/popover/stories/popover-with-event-base.component.ts
+++ b/packages/primitives/popover/stories/popover-with-event-base.component.ts
@@ -1,0 +1,123 @@
+import { NgTemplateOutlet } from '@angular/common';
+import { AfterContentInit, Component, computed, contentChild, ElementRef, inject, model, signal } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RdxPopoverContentDirective } from '../src/popover-content.directive';
+import { RdxPopoverRootDirective } from '../src/popover-root.directive';
+import { paramsAndEventsOnly } from './popover-styles.constants';
+
+@Component({
+    selector: 'popover-with-event-base',
+    styles: paramsAndEventsOnly,
+    template: `
+        <ng-content select=".ParamsContainer" />
+
+        @if (paramsContainerCounter()) {
+            <hr />
+        }
+
+        <div class="ParamsContainer">
+            (onEscapeKeyDown) prevent default:
+            <input
+                [ngModel]="onEscapeKeyDownPreventDefault()"
+                (ngModelChange)="onEscapeKeyDownPreventDefault.set($event)"
+                type="checkbox"
+            />
+            (onPointerDownOutside) prevent default:
+            <input
+                [ngModel]="onPointerDownOutsidePreventDefault()"
+                (ngModelChange)="onPointerDownOutsidePreventDefault.set($event)"
+                type="checkbox"
+            />
+        </div>
+
+        <ng-content />
+
+        @if (messages().length) {
+            <div class="MessagesContainer">
+                @for (message of messages(); track i; let i = $index) {
+                    <ng-container
+                        [ngTemplateOutlet]="messageTpl"
+                        [ngTemplateOutletContext]="{ message: message, index: messages().length - i }"
+                    />
+                }
+            </div>
+        }
+
+        <ng-template #messageTpl let-message="message" let-index="index">
+            <p class="Message">
+                {{ index }}.
+                <span class="MessageId">[POPOVER ID {{ rootUniqueId() }}]</span>
+                {{ message }}
+            </p>
+        </ng-template>
+    `,
+    imports: [
+        ReactiveFormsModule,
+        FormsModule,
+        NgTemplateOutlet
+    ],
+    standalone: true
+})
+export class PopoverWithEventBaseComponent implements AfterContentInit {
+    readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+
+    readonly popoverContentDirective = contentChild.required(RdxPopoverContentDirective);
+    readonly popoverRootDirective = contentChild.required(RdxPopoverRootDirective);
+
+    readonly paramsContainerCounter = signal(0);
+
+    readonly messages = model<string[]>([]);
+    readonly onEscapeKeyDownPreventDefault = signal(false);
+    readonly onPointerDownOutsidePreventDefault = signal(false);
+
+    readonly rootUniqueId = computed(() => this.popoverRootDirective().uniqueId());
+
+    containers: Element[] | undefined = void 0;
+
+    ngAfterContentInit() {
+        this.popoverContentDirective().onShow.subscribe(this.onShow);
+        this.popoverContentDirective().onHide.subscribe(this.onHide);
+        this.popoverContentDirective().onPointerDownOutside.subscribe(this.onPointerDownOutside);
+        this.popoverContentDirective().onEscapeKeyDown.subscribe(this.onEscapeKeyDown);
+        this.paramsContainerCounter.set(
+            this.elementRef.nativeElement?.querySelectorAll('.ParamsContainer').length ?? 0
+        );
+        this.containers = Array.from(this.elementRef.nativeElement?.querySelectorAll('.container') ?? []);
+    }
+
+    private inContainers(element: Element) {
+        return !!this.containers?.find((container) => container.contains(element));
+    }
+
+    private onEscapeKeyDown = (event: KeyboardEvent) => {
+        this.addMessage(`Escape clicked! (preventDefault: ${this.onEscapeKeyDownPreventDefault()})`);
+        this.onEscapeKeyDownPreventDefault() && event.preventDefault();
+    };
+
+    private onPointerDownOutside = (event: MouseEvent) => {
+        if (!event.target || !this.inContainers(event.target as HTMLElement)) {
+            return;
+        }
+        this.addMessage(
+            `Mouse clicked outside the popover! (preventDefault: ${this.onPointerDownOutsidePreventDefault()})`
+        );
+        this.onPointerDownOutsidePreventDefault() && event.preventDefault();
+    };
+
+    private onShow = () => {
+        this.addMessage('Popover shown!');
+    };
+
+    private onHide = () => {
+        this.addMessage('Popover hidden!');
+    };
+
+    protected addMessage = (message: string) => {
+        this.messages.update((messages) => {
+            return [
+                message,
+                ...messages
+            ];
+        });
+    };
+}

--- a/packages/primitives/popover/stories/popover.docs.mdx
+++ b/packages/primitives/popover/stories/popover.docs.mdx
@@ -34,6 +34,10 @@ import {RdxPopoverContentAttributesComponent} from "../src/popover-content-attri
 
 <Canvas sourceState="hidden" of={PopoverStories.ExternalTriggering} />
 
+### Initially Open
+
+<Canvas sourceState="hidden" of={PopoverStories.InitiallyOpen} />
+
 ### Animations
 
 <Canvas sourceState="hidden" of={PopoverStories.Animations} />
@@ -95,11 +99,13 @@ Contains all the parts of a popover.
 
 The button that toggles the popover. By default, the PopoverContent will position itself against the trigger.
 
-<Source type="code" language="md" code={`
-   | Data attribute | Value
-   | ----- | -----
-   | [data-state] | <code>"closed" | "open" (type RdxPopoverState)</code>
-`} />
+<Markdown>
+{`
+| Data attribute | Value          |
+|----------------|----------------|
+| [data-state]   | <code>"closed" | "open" (type RdxPopoverState)</code>
+`}
+</Markdown>
 
 ### Content
 `RdxPopoverContentDirective`
@@ -108,20 +114,22 @@ The component that pops out when the popover is open.
 
 <ArgTypes of={RdxPopoverContentDirective} />
 
-<Source type="code" language="md" code={`
-   | Data attribute | Value
-   | ----- | -----
-   | [data-state] | <code>"closed" | "open" (enum RdxPopoverState)</code>
-   | [data-side] | <code>"left" | "right" | "bottom" | "top" (enum RdxPopoverSide)</code>
-   | [data-align] | <code>"start" | "end" | "center" (enum RdxPopoverAlign)</code>
-`} />
-
 ### Content Attributes
 `RdxPopoverContentAttributesComponent`
 
 The component attributes that are necessary to run animations.
 
 <ArgTypes of={RdxPopoverContentAttributesComponent} />
+
+<Markdown>
+{`
+| Data attribute | Value          |
+|----------------|----------------|
+| [data-state]   | <code>"closed" | "open" (enum RdxPopoverState)</code>
+| [data-side]    | <code>"left"   | "right" | "bottom" | "top" (enum RdxPopoverSide)</code>
+| [data-align]   | <code>"start"  | "end" | "center" (enum RdxPopoverAlign)</code>
+`}
+</Markdown>
 
 ### Arrow
 `RdxPopoverArrowDirective`

--- a/packages/primitives/popover/stories/popover.docs.mdx
+++ b/packages/primitives/popover/stories/popover.docs.mdx
@@ -32,6 +32,151 @@ import {RdxPopoverCloseDirective} from "../src/popover-close.directive";
 
 <Canvas sourceState="hidden" of={PopoverStories.ExternalTriggering} />
 
+### Animations
+
+<Canvas sourceState="hidden" of={PopoverStories.Animations} />
+
+#### Custom Animation Styles
+
+```css
+/* Open animations */
+
+.rdx-custom-animated-content {
+    &:is(.rdx-custom-animated-content-open, .rdx-custom-animated-content-close) {
+        animation-duration: 400ms;
+        animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+        will-change: transform, opacity;
+    }
+
+    &.rdx-custom-animated-content-open {
+        &[data-state='open'][data-side='top'] {
+            animation-name: rdxCustomSlideDownAndFade;
+        }
+
+        &[data-state='open'][data-side='right'] {
+            animation-name: rdxCustomSlideLeftAndFade;
+        }
+
+        &[data-state='open'][data-side='bottom'] {
+            animation-name: rdxCustomSlideUpAndFade;
+        }
+
+        &[data-state='open'][data-side='left'] {
+            animation-name: rdxCustomSlideRightAndFade;
+        }
+    }
+
+    &.rdx-custom-animated-content-close {
+        &[data-state='closed'][data-side='top'] {
+            animation-name: rdxCustomSlideDownAndFadeReverse;
+        }
+
+        &[data-state='closed'][data-side='right'] {
+            animation-name: rdxCustomSlideLeftAndFadeReverse;
+        }
+
+        &[data-state='closed'][data-side='bottom'] {
+            animation-name: rdxCustomSlideUpAndFadeReverse;
+        }
+
+        &[data-state='closed'][data-side='left'] {
+            animation-name: rdxCustomSlideRightAndFadeReverse;
+        }
+    }
+}
+
+@keyframes rdxCustomSlideUpAndFade {
+    from {
+        opacity: 0;
+        transform: translateY(2px);
+        /*transition:left 1s linear;*/
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes rdxCustomSlideRightAndFade {
+    from {
+        opacity: 0;
+        transform: translateX(-2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@keyframes rdxCustomSlideDownAndFade {
+    from {
+        opacity: 0;
+        transform: translateY(-2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes rdxCustomSlideLeftAndFade {
+    from {
+        opacity: 0;
+        transform: translateX(2px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+/* Close animations */
+
+@keyframes rdxCustomSlideUpAndFadeReverse {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(2px);
+    }
+}
+
+@keyframes rdxCustomSlideRightAndFadeReverse {
+    from {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateX(-2px);
+    }
+}
+
+@keyframes rdxCustomSlideDownAndFadeReverse {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(-2px);
+    }
+}
+
+@keyframes rdxCustomSlideLeftAndFadeReverse {
+    from {
+        opacity: 1;
+        transform: translateX(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateX(2px);
+    }
+}
+```
+
 ## Features
 
 - ✅ Opens when the trigger is clicked.
@@ -45,7 +190,7 @@ import {RdxPopoverCloseDirective} from "../src/popover-close.directive";
     <button class="IconButton" rdxPopoverTrigger>+</button>
 
     <ng-template rdxPopoverContent [sideOffset]="8">
-        <div class="PopoverContent">
+        <div class="PopoverContent" rdxPopoverContentAttributes>
             <button class="PopoverClose" rdxPopoverClose aria-label="Close">X</button>
             Add to library
             <div class="PopoverArrow" rdxPopoverArrow></div>

--- a/packages/primitives/popover/stories/popover.docs.mdx
+++ b/packages/primitives/popover/stories/popover.docs.mdx
@@ -117,7 +117,7 @@ The component that pops out when the popover is open.
 ### Content Attributes
 `RdxPopoverContentAttributesComponent`
 
-The component attributes that are necessary to run animations.
+A component with the content attributes that are necessary to run animations.
 
 <ArgTypes of={RdxPopoverContentAttributesComponent} />
 

--- a/packages/primitives/popover/stories/popover.docs.mdx
+++ b/packages/primitives/popover/stories/popover.docs.mdx
@@ -1,9 +1,11 @@
-import { ArgTypes, Canvas, Markdown, Meta } from '@storybook/blocks';
+import {ArgTypes, Canvas, Markdown, Meta, Source} from '@storybook/blocks';
 import * as PopoverStories from "./popover.stories";
 import {RdxPopoverRootDirective} from "../src/popover-root.directive";
 import {RdxPopoverContentDirective} from "../src/popover-content.directive";
 import {RdxPopoverArrowDirective} from "../src/popover-arrow.directive";
 import {RdxPopoverCloseDirective} from "../src/popover-close.directive";
+import {animationStylesOnly} from "./popover-styles.constants";
+import {RdxPopoverContentAttributesComponent} from "../src/popover-content-attributes.component";
 
 <Meta title="Primitives/Popover" />
 
@@ -36,146 +38,10 @@ import {RdxPopoverCloseDirective} from "../src/popover-close.directive";
 
 <Canvas sourceState="hidden" of={PopoverStories.Animations} />
 
-#### Custom Animation Styles
+### Animation Styles
 
-```css
-/* Open animations */
+<Source type="code" language="css" code={`${animationStylesOnly}`} />
 
-.rdx-custom-animated-content {
-    &:is(.rdx-custom-animated-content-open, .rdx-custom-animated-content-close) {
-        animation-duration: 400ms;
-        animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-        will-change: transform, opacity;
-    }
-
-    &.rdx-custom-animated-content-open {
-        &[data-state='open'][data-side='top'] {
-            animation-name: rdxCustomSlideDownAndFade;
-        }
-
-        &[data-state='open'][data-side='right'] {
-            animation-name: rdxCustomSlideLeftAndFade;
-        }
-
-        &[data-state='open'][data-side='bottom'] {
-            animation-name: rdxCustomSlideUpAndFade;
-        }
-
-        &[data-state='open'][data-side='left'] {
-            animation-name: rdxCustomSlideRightAndFade;
-        }
-    }
-
-    &.rdx-custom-animated-content-close {
-        &[data-state='closed'][data-side='top'] {
-            animation-name: rdxCustomSlideDownAndFadeReverse;
-        }
-
-        &[data-state='closed'][data-side='right'] {
-            animation-name: rdxCustomSlideLeftAndFadeReverse;
-        }
-
-        &[data-state='closed'][data-side='bottom'] {
-            animation-name: rdxCustomSlideUpAndFadeReverse;
-        }
-
-        &[data-state='closed'][data-side='left'] {
-            animation-name: rdxCustomSlideRightAndFadeReverse;
-        }
-    }
-}
-
-@keyframes rdxCustomSlideUpAndFade {
-    from {
-        opacity: 0;
-        transform: translateY(2px);
-        /*transition:left 1s linear;*/
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes rdxCustomSlideRightAndFade {
-    from {
-        opacity: 0;
-        transform: translateX(-2px);
-    }
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
-}
-
-@keyframes rdxCustomSlideDownAndFade {
-    from {
-        opacity: 0;
-        transform: translateY(-2px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes rdxCustomSlideLeftAndFade {
-    from {
-        opacity: 0;
-        transform: translateX(2px);
-    }
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
-}
-
-/* Close animations */
-
-@keyframes rdxCustomSlideUpAndFadeReverse {
-    from {
-        opacity: 1;
-        transform: translateY(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateY(2px);
-    }
-}
-
-@keyframes rdxCustomSlideRightAndFadeReverse {
-    from {
-        opacity: 1;
-        transform: translateX(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateX(-2px);
-    }
-}
-
-@keyframes rdxCustomSlideDownAndFadeReverse {
-    from {
-        opacity: 1;
-        transform: translateY(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateY(-2px);
-    }
-}
-
-@keyframes rdxCustomSlideLeftAndFadeReverse {
-    from {
-        opacity: 1;
-        transform: translateX(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateX(2px);
-    }
-}
-```
 
 ## Features
 
@@ -203,21 +69,17 @@ import {RdxPopoverCloseDirective} from "../src/popover-close.directive";
 
 Get started with importing the directives:
 
-```typescript
-import {
+<Source type="code" language="typescript" code={`import {
   RdxPopoverRootDirective,
   RdxPopoverRootTrigger,
   RdxPopoverContentDirective,
   RdxPopoverArrowDirective,
   RdxPopoverCloseDirective
-} from '@radix-ng/primitives/popover';
-```
+} from '@radix-ng/primitives/popover';`} />
 
 or
 
-```typescript
-import { RdxPopoverModule } from '@radix-ng/primitives/popover';
-```
+<Source type="code" language="typescript" code={`import { RdxPopoverModule } from '@radix-ng/primitives/popover';`} />
 
 ## API Reference
 
@@ -233,13 +95,11 @@ Contains all the parts of a popover.
 
 The button that toggles the popover. By default, the PopoverContent will position itself against the trigger.
 
-<Markdown>
-    {`
+<Source type="code" language="md" code={`
    | Data attribute | Value
    | ----- | -----
    | [data-state] | <code>"closed" | "open" (type RdxPopoverState)</code>
-   `}
-</Markdown>
+`} />
 
 ### Content
 `RdxPopoverContentDirective`
@@ -248,15 +108,20 @@ The component that pops out when the popover is open.
 
 <ArgTypes of={RdxPopoverContentDirective} />
 
-<Markdown>
-    {`
+<Source type="code" language="md" code={`
    | Data attribute | Value
    | ----- | -----
    | [data-state] | <code>"closed" | "open" (enum RdxPopoverState)</code>
    | [data-side] | <code>"left" | "right" | "bottom" | "top" (enum RdxPopoverSide)</code>
    | [data-align] | <code>"start" | "end" | "center" (enum RdxPopoverAlign)</code>
-   `}
-</Markdown>
+`} />
+
+### Content Attributes
+`RdxPopoverContentAttributesComponent`
+
+The component attributes that are necessary to run animations.
+
+<ArgTypes of={RdxPopoverContentAttributesComponent} />
 
 ### Arrow
 `RdxPopoverArrowDirective`

--- a/packages/primitives/popover/stories/popover.stories.ts
+++ b/packages/primitives/popover/stories/popover.stories.ts
@@ -2,6 +2,7 @@ import { provideAnimations } from '@angular/platform-browser/animations';
 import { componentWrapperDecorator, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { LucideAngularModule, MountainSnowIcon, X } from 'lucide-angular';
 import { RdxPopoverModule } from '../index';
+import { RdxPopoverAnimationsComponent } from './popover-animations.component';
 import { RdxPopoverDefaultComponent } from './popover-default.component';
 import { RdxPopoverEventsComponent } from './popover-events.components';
 import { RdxPopoverMultipleComponent } from './popover-multiple.component';
@@ -21,6 +22,7 @@ export default {
                 RdxPopoverPositioningComponent,
                 RdxPopoverTriggeringComponent,
                 RdxPopoverMultipleComponent,
+                RdxPopoverAnimationsComponent,
                 LucideAngularModule,
                 LucideAngularModule.pick({ MountainSnowIcon, X })
             ],
@@ -79,6 +81,14 @@ export const ExternalTriggering: Story = {
     render: () => ({
         template: html`
             <rdx-popover-triggering></rdx-popover-triggering>
+        `
+    })
+};
+
+export const Animations: Story = {
+    render: () => ({
+        template: html`
+            <rdx-popover-animations></rdx-popover-animations>
         `
     })
 };

--- a/packages/primitives/popover/stories/popover.stories.ts
+++ b/packages/primitives/popover/stories/popover.stories.ts
@@ -5,6 +5,7 @@ import { RdxPopoverModule } from '../index';
 import { RdxPopoverAnimationsComponent } from './popover-animations.component';
 import { RdxPopoverDefaultComponent } from './popover-default.component';
 import { RdxPopoverEventsComponent } from './popover-events.components';
+import { RdxPopoverInitiallyOpenComponent } from './popover-initially-open.component';
 import { RdxPopoverMultipleComponent } from './popover-multiple.component';
 import { RdxPopoverPositioningComponent } from './popover-positioning.component';
 import { RdxPopoverTriggeringComponent } from './popover-triggering.component';
@@ -23,6 +24,7 @@ export default {
                 RdxPopoverTriggeringComponent,
                 RdxPopoverMultipleComponent,
                 RdxPopoverAnimationsComponent,
+                RdxPopoverInitiallyOpenComponent,
                 LucideAngularModule,
                 LucideAngularModule.pick({ MountainSnowIcon, X })
             ],
@@ -81,6 +83,14 @@ export const ExternalTriggering: Story = {
     render: () => ({
         template: html`
             <rdx-popover-triggering></rdx-popover-triggering>
+        `
+    })
+};
+
+export const InitiallyOpen: Story = {
+    render: () => ({
+        template: html`
+            <rdx-popover-initially-open></rdx-popover-initially-open>
         `
     })
 };

--- a/packages/primitives/tsconfig.lib.json
+++ b/packages/primitives/tsconfig.lib.json
@@ -5,7 +5,8 @@
         "declaration": true,
         "declarationMap": true,
         "inlineSources": true,
-        "types": []
+        "types": ["node", "global"],
+        "typeRoots": ["../../node_modules/@types", "./"]
     },
     "exclude": [
         "**/*.spec.ts",

--- a/packages/primitives/tsconfig.spec.json
+++ b/packages/primitives/tsconfig.spec.json
@@ -4,7 +4,8 @@
         "outDir": "../../dist/out-tsc",
         "module": "commonjs",
         "target": "es2016",
-        "types": ["jest", "node"]
+        "types": ["jest", "node", "global"],
+        "typeRoots": ["../../node_modules/@types", "./"]
     },
     "files": ["test-setup.ts"],
     "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]


### PR DESCRIPTION
Closes #196

allows animation on the popover content while opening/closing it.

Pure CSS animation.

`rdxPopoverContentAttributes` is required to get animations work:

```HTML
<ng-template rdxPopoverContent>
  <div rdxPopoverContentAttributes />
</ng-template>
```

It can get disabled with `[cssAnimation]="false"` on the root directive.

Opening or closing animation can get disabled with `[cssOnShowAnimation]="false"` or `[cssOnCloseAnimation]="false"` on the root directive.

It can get customized with `[cssAnimation]="'custom'"` on the root directive and with the neccessary CSS rules applied to the element having `rdxPopoverContentAttributes` on it:

```HTML
<ng-container rdxPopoverRoot [cssAnimation]="'custom'">
  <ng-template rdxPopoverContent>
    <div class="rdx-custom-animation" rdxPopoverContentAttributes />
  </ng-template>
</ng-container>
```

At some point it looks like the animation is veery fast :) but it is just me who is clicking that fast :D

https://github.com/user-attachments/assets/7f0ac3a1-323d-4f2c-8246-c2f56b0cdba9