### PR TITLE
feat(toggle): rename visually hidden directive for input, upd storybook

### DIFF
--- a/packages/primitives/toggle/__tests__/toggle.directive.spec.ts
+++ b/packages/primitives/toggle/__tests__/toggle.directive.spec.ts
@@ -55,10 +55,10 @@ describe('RdxToggleDirective', () => {
     });
 
     it('should apply the correct data-disabled attribute', () => {
-        expect(button.nativeElement.getAttribute('data-disabled')).toBe('false');
+        expect(button.nativeElement.getAttribute('data-disabled')).toBe(null);
         component.disabled = true;
         fixture.detectChanges();
-        expect(button.nativeElement.getAttribute('data-disabled')).toBe('true');
+        expect(button.nativeElement.getAttribute('data-disabled')).toBe('');
     });
 
     it('should toggle the pressed state on click', () => {

--- a/packages/primitives/toggle/index.ts
+++ b/packages/primitives/toggle/index.ts
@@ -1,4 +1,4 @@
-export * from './src/toggle-input.directive';
+export * from './src/toggle-visually-hidden-input.directive';
 export * from './src/toggle.directive';
 
-export type { ToggleProps } from './src/toggle.directive';
+export type { DataState, ToggleProps } from './src/toggle.directive';

--- a/packages/primitives/toggle/src/toggle-visually-hidden-input.directive.ts
+++ b/packages/primitives/toggle/src/toggle-visually-hidden-input.directive.ts
@@ -2,8 +2,8 @@ import { Directive } from '@angular/core';
 import { RdxVisuallyHiddenInputDirective } from '@radix-ng/primitives/visually-hidden';
 
 @Directive({
-    selector: '[rdxToggleInput]',
-    exportAs: 'rdxToggleInput',
+    selector: 'input[rdxToggleVisuallyHiddenInput]',
+    exportAs: 'rdxToggleVisuallyHiddenInput',
     standalone: true,
     hostDirectives: [
         {
@@ -11,7 +11,8 @@ import { RdxVisuallyHiddenInputDirective } from '@radix-ng/primitives/visually-h
             inputs: [
                 'name',
                 'required',
-                'value'
+                'value',
+                'disabled'
             ]
         }
     ],
@@ -19,4 +20,4 @@ import { RdxVisuallyHiddenInputDirective } from '@radix-ng/primitives/visually-h
         type: 'checkbox'
     }
 })
-export class RdxToggleInputDirective {}
+export class RdxToggleVisuallyHiddenInputDirective {}

--- a/packages/primitives/toggle/src/toggle.directive.ts
+++ b/packages/primitives/toggle/src/toggle.directive.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Directive, input, model, output, OutputEmitterRef } from '@angular/core';
+import { booleanAttribute, computed, Directive, input, model, output, OutputEmitterRef } from '@angular/core';
 
 export interface ToggleProps {
     /**
@@ -26,17 +26,19 @@ export interface ToggleProps {
     disabled?: boolean;
 }
 
+export type DataState = 'on' | 'off';
+
 @Directive({
     selector: '[rdxToggle]',
     exportAs: 'rdxToggle',
     standalone: true,
     host: {
         '[attr.aria-pressed]': 'pressed()',
-        '[attr.data-state]': 'pressed() ? "on" : "off"',
-        '[attr.data-disabled]': 'disabled()',
+        '[attr.data-state]': 'dataState()',
+        '[attr.data-disabled]': 'disabled() ? "" : undefined',
         '[disabled]': 'disabled()',
 
-        '(click)': 'toggle()'
+        '(click)': 'togglePressed()'
     }
 })
 export class RdxToggleDirective {
@@ -57,12 +59,16 @@ export class RdxToggleDirective {
      */
     readonly disabled = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
+    protected readonly dataState = computed<DataState>(() => {
+        return this.pressed() ? 'on' : 'off';
+    });
+
     /**
      * Event handler called when the pressed state of the toggle changes.
      */
     readonly onPressedChange = output<boolean>();
 
-    protected toggle(): void {
+    protected togglePressed(): void {
         if (!this.disabled()) {
             this.pressed.set(!this.pressed());
             this.onPressedChange.emit(this.pressed());

--- a/packages/primitives/toggle/src/toggle.directive.ts
+++ b/packages/primitives/toggle/src/toggle.directive.ts
@@ -97,15 +97,18 @@ export class RdxToggleDirective implements ControlValueAccessor {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     private onTouched: Function = () => {};
 
+    /** @ignore */
     writeValue(value: any): void {
         this.pressed.set(value);
     }
 
+    /** @ignore */
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     registerOnChange(fn: Function): void {
         this.onChange = fn;
     }
 
+    /** @ignore */
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     registerOnTouched(fn: Function): void {
         this.onTouched = fn;

--- a/packages/primitives/toggle/src/toggle.directive.ts
+++ b/packages/primitives/toggle/src/toggle.directive.ts
@@ -1,5 +1,15 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, computed, Directive, input, model, output, OutputEmitterRef } from '@angular/core';
+import {
+    booleanAttribute,
+    computed,
+    Directive,
+    forwardRef,
+    input,
+    model,
+    output,
+    OutputEmitterRef
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 export interface ToggleProps {
     /**
@@ -28,10 +38,17 @@ export interface ToggleProps {
 
 export type DataState = 'on' | 'off';
 
+export const TOGGLE_VALUE_ACCESSOR: any = {
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => RdxToggleDirective),
+    multi: true
+};
+
 @Directive({
     selector: '[rdxToggle]',
     exportAs: 'rdxToggle',
     standalone: true,
+    providers: [TOGGLE_VALUE_ACCESSOR],
     host: {
         '[attr.aria-pressed]': 'pressed()',
         '[attr.data-state]': 'dataState()',
@@ -41,7 +58,7 @@ export type DataState = 'on' | 'off';
         '(click)': 'togglePressed()'
     }
 })
-export class RdxToggleDirective {
+export class RdxToggleDirective implements ControlValueAccessor {
     /**
      * The pressed state of the toggle when it is initially rendered.
      * Use when you do not need to control its pressed state.
@@ -73,5 +90,24 @@ export class RdxToggleDirective {
             this.pressed.set(!this.pressed());
             this.onPressedChange.emit(this.pressed());
         }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    private onChange: Function = () => {};
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    private onTouched: Function = () => {};
+
+    writeValue(value: any): void {
+        this.pressed.set(value);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    registerOnChange(fn: Function): void {
+        this.onChange = fn;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    registerOnTouched(fn: Function): void {
+        this.onTouched = fn;
     }
 }

--- a/packages/primitives/toggle/stories/toggle-forms.component.ts
+++ b/packages/primitives/toggle/stories/toggle-forms.component.ts
@@ -1,0 +1,37 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { RdxToggleVisuallyHiddenInputDirective } from '../src/toggle-visually-hidden-input.directive';
+import { RdxToggleDirective } from '../src/toggle.directive';
+
+@Component({
+    selector: 'toggle-reactive-forms',
+    standalone: true,
+    imports: [ReactiveFormsModule, RdxToggleDirective, RdxToggleVisuallyHiddenInputDirective],
+    styleUrl: 'toggle.styles.css',
+    template: `
+        <form [formGroup]="formGroup">
+            <button class="Toggle" #toggle="rdxToggle" [pressed]="false" rdxToggle aria-label="Toggle bold">
+                <input
+                    [name]="'toggleDef'"
+                    [value]="toggle.pressed()"
+                    [required]="false"
+                    rdxToggleVisuallyHiddenInput
+                />
+                @if (toggle.pressed()) {
+                    On
+                } @else {
+                    Off
+                }
+            </button>
+        </form>
+    `
+})
+export class ToggleButtonReactiveForms implements OnInit {
+    formGroup!: FormGroup;
+
+    ngOnInit() {
+        this.formGroup = new FormGroup({
+            pressed: new FormControl<boolean>(false)
+        });
+    }
+}

--- a/packages/primitives/toggle/stories/toggle-forms.component.ts
+++ b/packages/primitives/toggle/stories/toggle-forms.component.ts
@@ -10,10 +10,10 @@ import { RdxToggleDirective } from '../src/toggle.directive';
     styleUrl: 'toggle.styles.css',
     template: `
         <form [formGroup]="formGroup">
-            <button class="Toggle" #toggle="rdxToggle" [pressed]="false" rdxToggle aria-label="Toggle bold">
+            <button class="Toggle" #toggle="rdxToggle" formControlName="pressed" rdxToggle aria-label="Toggle bold">
                 <input
                     [name]="'toggleDef'"
-                    [value]="toggle.pressed()"
+                    [value]="toggle.pressed() ? 'on' : 'off'"
                     [required]="false"
                     rdxToggleVisuallyHiddenInput
                 />
@@ -31,7 +31,7 @@ export class ToggleButtonReactiveForms implements OnInit {
 
     ngOnInit() {
         this.formGroup = new FormGroup({
-            pressed: new FormControl<boolean>(false)
+            pressed: new FormControl<boolean>(true)
         });
     }
 }

--- a/packages/primitives/toggle/stories/toggle.docs.mdx
+++ b/packages/primitives/toggle/stories/toggle.docs.mdx
@@ -1,6 +1,7 @@
 import { ArgTypes, Canvas, Markdown, Meta } from '@storybook/blocks';
 import * as ToggleDirectiveStories from './toggle.stories';
 import { RdxToggleDirective } from '../src/toggle.directive';
+import { RdxToggleVisuallyHiddenInputDirective } from '../src/toggle-visually-hidden-input.directive';
 
 <Meta title="Primitives/Toggle" />
 
@@ -33,18 +34,30 @@ import { RdxToggleDirective } from '@radix-ng/primitives/toggle';
 
 ## API Reference
 
-### RdxToggleDirective
+### Toggle
+
+`RdxToggleDirective`
+
+The toggle.
 
 <ArgTypes of={RdxToggleDirective} />
 
 <Markdown>
-  {`
+    {`
   | Data Attribute | Value |
   | ----------- | --------- |
   | [data-state]       | "on" or "off"   |
   | [data-disabled]    | Present when disabled      |
   `}
 </Markdown>
+
+### ToggleInput
+
+`RdxToggleVisuallyHiddenInputDirective`
+
+Directive for a visually hidden `<input />`element, specifically designed for use with toggle components.
+This directive simplifies the integration of hidden form inputs in toggle components, ensuring compatibility with form handling while maintaining a clean and accessible design.
+
 
 ## Accessibility
 

--- a/packages/primitives/toggle/stories/toggle.docs.mdx
+++ b/packages/primitives/toggle/stories/toggle.docs.mdx
@@ -23,7 +23,7 @@ Get started with importing the directives:
 import { RdxToggleDirective } from '@radix-ng/primitives/toggle';
 ```
 
-## Examples
+## Anatomy
 
 ```html
 <button rdxToggle aria-label="Toggle italic">
@@ -58,3 +58,16 @@ import { RdxToggleDirective } from '@radix-ng/primitives/toggle';
   | Enter       | Activates/deactivates the toggle.  |
   `}
 </Markdown>
+
+
+## Examples
+
+### Reactive Forms
+
+Toggle can also be used with reactive forms. In this case, the formControlName property is used to bind the component to a form control.
+<Canvas sourceState="hidden" of={ToggleDirectiveStories.ReactiveForm} />
+
+### Disabled
+
+When disabled is present, the element cannot be edited and focused.
+<Canvas sourceState="hidden" of={ToggleDirectiveStories.Disabled} />

--- a/packages/primitives/toggle/stories/toggle.stories.ts
+++ b/packages/primitives/toggle/stories/toggle.stories.ts
@@ -1,7 +1,8 @@
 import { componentWrapperDecorator, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { Italic, LucideAngularModule } from 'lucide-angular';
-import { RdxToggleInputDirective } from '../src/toggle-input.directive';
+import { RdxToggleVisuallyHiddenInputDirective } from '../src/toggle-visually-hidden-input.directive';
 import { RdxToggleDirective } from '../src/toggle.directive';
+import { ToggleButtonReactiveForms } from './toggle-forms.component';
 
 const html = String.raw;
 
@@ -11,7 +12,8 @@ export default {
         moduleMetadata({
             imports: [
                 RdxToggleDirective,
-                RdxToggleInputDirective,
+                RdxToggleVisuallyHiddenInputDirective,
+                ToggleButtonReactiveForms,
                 LucideAngularModule,
                 LucideAngularModule.pick({ Italic })
             ]
@@ -107,7 +109,12 @@ export const Controlled: Story = {
             <h1>Uncontrolled</h1>
             <span class="">default off</span>
             <button class="Toggle" rdxToggle [pressed]="false" aria-label="Toggle bold" #toggle="rdxToggle">
-                <input rdxToggleInput [name]="'toggleDef'" [value]="toggle.pressed()" [required]="false" />
+                <input
+                    rdxToggleVisuallyHiddenInput
+                    [name]="'toggleDef'"
+                    [value]="toggle.pressed()"
+                    [required]="false"
+                />
                 <lucide-angular name="italic" size="12"></lucide-angular>
             </button>
 
@@ -121,7 +128,12 @@ export const Controlled: Story = {
                 aria-label="Toggle bold"
                 #toggle="rdxToggle"
             >
-                <input rdxToggleInput [name]="'toggleDef'" [value]="toggle.pressed()" [required]="false" />
+                <input
+                    rdxToggleVisuallyHiddenInput
+                    [name]="'toggleDef'"
+                    [value]="toggle.pressed()"
+                    [required]="false"
+                />
                 <lucide-angular name="italic" size="12"></lucide-angular>
             </button>
 
@@ -134,16 +146,51 @@ export const Controlled: Story = {
                 aria-label="Toggle bold"
                 #toggle="rdxToggle"
             >
-                <input rdxToggleInput [name]="'toggleDef'" [value]="toggle.pressed()" [required]="false" />
+                <input
+                    rdxToggleVisuallyHiddenInput
+                    [name]="'toggleDef'"
+                    [value]="toggle.pressed()"
+                    [required]="false"
+                />
                 <lucide-angular name="italic" size="12"></lucide-angular>
             </button>
 
             <h1>Events</h1>
             <span class="">default off</span>
             <button class="Toggle" rdxToggle [pressed]="false" aria-label="Toggle bold" #toggle="rdxToggle">
-                <input rdxToggleInput [name]="'toggleDef'" [value]="toggle.pressed()" [required]="false" />
+                <input
+                    rdxToggleVisuallyHiddenInput
+                    [name]="'toggleDef'"
+                    [value]="toggle.pressed()"
+                    [required]="false"
+                />
                 <lucide-angular name="italic" size="12"></lucide-angular>
             </button>
+        `
+    })
+};
+
+export const Disabled: Story = {
+    render: () => ({
+        template: html`
+            <button class="Toggle" disabled rdxToggle #toggle="rdxToggle" aria-label="Toggle disabled">
+                <input
+                    rdxToggleVisuallyHiddenInput
+                    [name]="'toggleDef'"
+                    [value]="toggle.pressed()"
+                    [required]="false"
+                    [disabled]="toggle.disabled()"
+                />
+                <lucide-angular name="italic" size="12"></lucide-angular>
+            </button>
+        `
+    })
+};
+
+export const ReactiveForm: Story = {
+    render: () => ({
+        template: html`
+            <toggle-reactive-forms></toggle-reactive-forms>
         `
     })
 };

--- a/packages/primitives/toggle/stories/toggle.styles.css
+++ b/packages/primitives/toggle/stories/toggle.styles.css
@@ -1,0 +1,35 @@
+button {
+    all: unset;
+}
+
+.Toggle {
+    background-color: white;
+    color: var(--mauve-11);
+    height: 35px;
+    width: 35px;
+    border-radius: 4px;
+    display: flex;
+    font-size: 15px;
+    line-height: 1;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 10px var(--black-a7);
+}
+
+.Toggle:hover {
+    background-color: var(--violet-3);
+}
+
+.Toggle[disabled] {
+    pointer-events: none;
+    opacity: 0.5;
+}
+
+.Toggle[data-state='on'] {
+    background-color: var(--violet-6);
+    color: var(--violet-12);
+}
+
+.Toggle:focus {
+    box-shadow: 0 0 0 2px black;
+}


### PR DESCRIPTION
**Renaming of Directive**: 
       The directive previously named `RdxToggleInputDirective` has been renamed to `RdxVisuallyHiddenInputDirective`.

**Storybook Updates**:
        The Storybook entries for the rdxToggle component have been updated to reflect the directive renaming and to enhance documentation and examples.

