### PR TITLE
fix(popover): close popover on anchor click

### DIFF
--- a/packages/primitives/popover/src/popover-anchor.directive.ts
+++ b/packages/primitives/popover/src/popover-anchor.directive.ts
@@ -51,11 +51,18 @@ export class RdxPopoverAnchorDirective {
     }
 
     private emitOutsideClick() {
+        if (
+            !this.popoverRoot?.isOpen() ||
+            this.popoverRoot?.popoverContentDirective().onOverlayOutsideClickDisabled()
+        ) {
+            return;
+        }
         const clickEvent = new MouseEvent('click', {
             view: this.document.defaultView,
             bubbles: true,
-            cancelable: true
+            cancelable: true,
+            relatedTarget: this.elementRef.nativeElement
         });
-        this.document.body.dispatchEvent(clickEvent);
+        this.popoverRoot?.popoverTriggerDirective().elementRef.nativeElement.dispatchEvent(clickEvent);
     }
 }


### PR DESCRIPTION
Closes #222

### Description

After this fix, what happens on `anchor` click:
- if `popover` is closed - nothing
- if `popover` is open - it will get closed
