### PR TITLE
fix(navigation-menu): simplify viewport content existence validation

### DIFF
--- a/packages/primitives/navigation-menu/src/navigation-menu-viewport.directive.ts
+++ b/packages/primitives/navigation-menu/src/navigation-menu-viewport.directive.ts
@@ -272,7 +272,7 @@ export class RdxNavigationMenuViewportDirective implements OnInit, OnDestroy {
     private updateActiveContent(contentNode: ContentNode) {
         if (contentNode !== this._activeContentNode()) {
             // clear viewport
-            while (this.elementRef.nativeElement.firstChild) {
+            if (this.elementRef.nativeElement.firstChild) {
                 this.renderer.removeChild(this.elementRef.nativeElement, this.elementRef.nativeElement.firstChild);
             }
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Sometimes the `DynamicDelegateRenderer` will mark an element for removal without actually removing the element. This will cause the check for a child element (in this case, `div.NavigationMenuContentWrapper`) to always be true, and cause an infinite loop.

This adjusts the `updateActiveContent` function to only check for existing viewport content once to avoid these eventualities.
