### PR TITLE
fix(dialog): ensure `data-state` and `data-side`  are set on CDK backdrop

### DIFF
--- a/packages/primitives/dialog/src/dialog.config.ts
+++ b/packages/primitives/dialog/src/dialog.config.ts
@@ -34,6 +34,8 @@ type RdxBaseDialogConfig<C> = {
 
     canCloseWithBackdrop?: boolean;
 
+    closeDelay?: number;
+
     cdkConfigOverride?: Partial<DialogConfig<C>>;
 
     mode?: RdxDialogMode;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

This PR enhances the Dialog (and Sheet) primitive by adding animation support through `data-state` attributes. Previously, the CDK overlay elements (panel and backdrop) had no way to be animated during open/close transitions because they lacked state tracking outside of customizing the `panelClasses` option.

Another notable update here is the addition of a `closeDelay` Dialog config property. This defaults to zero, but if you want to do exit animations, you can set this to the duration (in ms) that will wait until the dialog is disposed. This gives CSS animations time to complete prior to disposal.
