### PR TITLE
fix(navigation-menu): remove unnecessary triggerEnter handler

### DIFF
--- a/packages/primitives/navigation-menu/src/navigation-menu-trigger.directive.ts
+++ b/packages/primitives/navigation-menu/src/navigation-menu-trigger.directive.ts
@@ -171,8 +171,6 @@ export class RdxNavigationMenuTriggerDirective extends RdxNavigationMenuFocusabl
         ) {
             return;
         }
-        // trigger enter logic (handles delays) and mark that this move initiated an open attempt
-        this.context.onTriggerEnter?.(this.item.value());
         this.hasPointerMoveOpened = true;
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

This is a small PR that fixes a potential race condition where the previously active ViewportContents would not be disposed as the `previousValue` would be incorrectly assigned twice, causing `previousValue` to be equivalent to the _current_ viewport `value`. This ultimately would leave N number of `.NavigationMenuContentWrapper` instances in the DOM, causing them overlap each other.
