### PR TITLE
feat(select): observe trigger size to update overlay dimensions

### DIFF
--- a/packages/primitives/select/src/select-trigger.directive.ts
+++ b/packages/primitives/select/src/select-trigger.directive.ts
@@ -1,4 +1,4 @@
-import { ContentChild, Directive, ElementRef, inject } from '@angular/core';
+import { AfterViewInit, contentChild, Directive, ElementRef, inject, NgZone, OnDestroy } from '@angular/core';
 import { RdxSelectValueDirective } from './select-value.directive';
 import { RdxSelectComponent } from './select.component';
 
@@ -12,20 +12,45 @@ import { RdxSelectComponent } from './select.component';
         '[attr.dir]': 'select.dir.value',
         '[attr.aria-expanded]': 'select.open',
         '[attr.aria-required]': 'select.required',
-
         '[attr.disabled]': 'select.disabled ? "" : null',
         '[attr.data-disabled]': 'select.disabled ? "" : null',
         '[attr.data-state]': "select.open ? 'open': 'closed'",
-        '[attr.data-placeholder]': 'value.placeholder || null'
+        '[attr.data-placeholder]': 'value().placeholder || null'
     }
 })
-export class RdxSelectTriggerDirective {
+export class RdxSelectTriggerDirective implements AfterViewInit, OnDestroy {
+    readonly ngZone = inject(NgZone);
     protected nativeElement = inject(ElementRef).nativeElement;
     protected select = inject(RdxSelectComponent);
 
-    @ContentChild(RdxSelectValueDirective) protected value: RdxSelectValueDirective;
+    protected readonly value = contentChild.required(RdxSelectValueDirective);
+
+    private resizeObserver: ResizeObserver | null;
+
+    ngAfterViewInit(): void {
+        this.select.triggerSize.set([this.nativeElement.offsetWidth, this.nativeElement.offsetHeight]);
+        this.observeTriggerResize();
+    }
+
+    ngOnDestroy(): void {
+        this.resizeObserver?.disconnect();
+        this.resizeObserver = null;
+    }
 
     focus() {
         this.nativeElement.focus();
+    }
+
+    private observeTriggerResize() {
+        if (typeof ResizeObserver === 'undefined' || !ResizeObserver) {
+            return;
+        }
+
+        this.ngZone.runOutsideAngular(() => {
+            this.resizeObserver = new ResizeObserver(() => {
+                this.select.triggerSize.set([this.nativeElement.offsetWidth, this.nativeElement.offsetHeight]);
+            });
+            this.resizeObserver.observe(this.nativeElement);
+        });
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This PR adjusts the Select primitive to align more closely with Radix UI's primitive functionality in that the overlay width matches that of the underlying select "trigger".

Similarly, this also exposes `--radix-select-trigger-width` and `--radix-select-trigger-height` CSS variables on the `RdxSelectComponent` host to allow for closer mappings to either shadcn or OriginUI's components.

The `RdxSelectComponent` has also been updated to use CDK options that offer additional flexibility.

Lastly, this migrates the Select primitive to use signal-driven utility functions.
