### PR TITLE
feat(select): enhance overlay width handling and improve item display

### DIFF
--- a/packages/primitives/select/src/select.component.ts
+++ b/packages/primitives/select/src/select.component.ts
@@ -40,7 +40,9 @@ let nextId = 0;
             [cdkConnectedOverlayOrigin]="elementRef"
             [cdkConnectedOverlayPositions]="positions"
             [cdkConnectedOverlayScrollStrategy]="overlay.scrollStrategies.reposition()"
-            [cdkConnectedOverlayWidth]="triggerWidth() > 0 ? triggerWidth() : 'auto'"
+            [cdkConnectedOverlayMinWidth]="triggerWidth() > 0 ? triggerWidth() : 'auto'"
+            [cdkConnectedOverlayWidth]="matchTriggerWidth ? triggerWidth() : 'auto'"
+            [cdkConnectedOverlay]
             (attach)="onAttached()"
             (backdropClick)="close()"
             (detach)="onDetach()"
@@ -142,6 +144,12 @@ export class RdxSelectComponent implements OnInit, AfterContentInit {
     @Input({ transform: booleanAttribute }) disabled: boolean;
 
     @Input({ transform: booleanAttribute }) required: boolean;
+
+    /**
+     * The overlay width will be set to the trigger width if this is true.
+     * Otherwise, the overlay width will be set to the width of the content.
+     */
+    @Input({ transform: booleanAttribute }) matchTriggerWidth: boolean = false;
 
     /**
      * The controlled value of the item to expand

--- a/packages/primitives/select/stories/select.stories.ts
+++ b/packages/primitives/select/stories/select.stories.ts
@@ -93,6 +93,7 @@ export default {
 
                     .SelectViewport {
                         padding: 5px;
+                        width: 100%;
                     }
 
                     .SelectItem {
@@ -106,6 +107,11 @@ export default {
                         padding: 0 35px 0 25px;
                         position: relative;
                         user-select: none;
+                    }
+                    .SelectItem span {
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                        overflow: hidden;
                     }
                     .SelectItem[data-disabled] {
                         color: var(--mauve-8);
@@ -212,7 +218,7 @@ export const Default: Story = {
                         @for (food of group.foods; track food) {
                         <div class="SelectItem" rdxSelectItem [value]="food.value" [disabled]="food.disabled">
                             <lucide-icon class="SelectItemIndicator" rdxSelectItemIndicator size="16" name="check" />
-                            {{ food.label }}
+                            <span>{{ food.label }}</span>
                         </div>
                         }
                     </div>


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

This fixes some select popup content width regressions that were introduced in #325, specifically around handling content that becomes unreadable if the trigger gets too small.

To work around this, the CDK Overlay that `RdxSelectComponent` leverages now sets the `cdkConnectedOverlayMinWidth` with a default value to the trigger size. 

To accommodate those who wish to have the content overlay match the trigger width though, a new input `matchTriggerWidth` has been added to `RdxSelectComponent` which, when set to `true`, sets the `cdkConnectedOverlayWidth` value to the trigger width.

### Using `[matchTriggerWidth]="false"` (default)

![image](https://github.com/user-attachments/assets/3222336e-4601-43ae-93e3-8f7c72d5fe8a)

### Using `[matchTriggerWidth]="true"`

![image](https://github.com/user-attachments/assets/c3f8dd4b-6661-42e6-8ca4-7aa3e640b7c6)

Note: @pimenovoleg to enable truncation, I had to slightly modify the markup and added a new set of styles to make that happen. This however moves away from establishing parity with the Radix UI project's styles. Not sure if this is an issue, but I wanted to at least point that out.

Fixes #329 
