### PR TITLE
fix(navigation-menu): clear viewport size when no active content node is present

### DIFF
--- a/packages/primitives/navigation-menu/src/navigation-menu-viewport.directive.ts
+++ b/packages/primitives/navigation-menu/src/navigation-menu-viewport.directive.ts
@@ -347,6 +347,10 @@ export class RdxNavigationMenuViewportDirective implements OnInit, OnDestroy {
 
             node.transitionSubscription = null;
             this._leavingContentNode.set(null);
+
+            if (!this._activeContentNode() && !this.forceMount()) {
+                this._viewportSize.set(null);
+            }
         } else {
             // if this node is NOT the one currently marked as leaving, it means
             // a new transition started before this one finished. Just clean up DOM/Sub.


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Fixed an issue in the NavigationMenu viewport where custom CSS properties (`--radix-navigation-menu-viewport-width` and `--radix-navigation-menu-viewport-height`) persisted after the menu viewport closed, causing layout issues as closed viewports retained their last dimensions instead of resetting to zero.

The solution modifies the `cleanupAfterLeave` method in `RdxNavigationMenuViewportDirective` to reset the `_viewportSize` signal to null after leave transitions complete when there's no active content.
