### PR TITLE
fix(navigation-menu): prevent accidental menu closing when clicking immediately after hover

### DIFF
--- a/packages/primitives/navigation-menu/src/navigation-menu.directive.ts
+++ b/packages/primitives/navigation-menu/src/navigation-menu.directive.ts
@@ -56,6 +56,8 @@ export class RdxNavigationMenuDirective implements OnDestroy {
     private openTimerRef = 0;
     private closeTimerRef = 0;
     private skipDelayTimerRef = 0;
+    private recentlyActivatedTimerRef = 0;
+    private readonly recentlyActivatedItem = signal<string | null>(null);
     readonly #isOpenDelayed = signal(true);
 
     // pointer tracking
@@ -68,7 +70,8 @@ export class RdxNavigationMenuDirective implements OnDestroy {
     @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
     @Input() dir: 'ltr' | 'rtl' = 'ltr';
     @Input({ transform: numberAttribute }) delayDuration = 200;
-    @Input({ transform: numberAttribute }) skipDelayDuration = 300;
+    @Input({ transform: numberAttribute }) clickIgnoreDuration = 350;
+    @Input({ transform: numberAttribute }) skipDelayDuration = 75;
     @Input({ transform: booleanAttribute }) loop = false;
     @Input({ transform: booleanAttribute }) cssAnimation = false;
     @Input({ transform: booleanAttribute }) cssOpeningAnimation = false;
@@ -148,6 +151,7 @@ export class RdxNavigationMenuDirective implements OnDestroy {
         this.window.clearTimeout(this.openTimerRef);
         this.window.clearTimeout(this.closeTimerRef);
         this.window.clearTimeout(this.skipDelayTimerRef);
+        this.window.clearTimeout(this.recentlyActivatedTimerRef);
 
         // clean up document event listener
         if (this.documentMouseLeaveHandler) {
@@ -198,6 +202,17 @@ export class RdxNavigationMenuDirective implements OnDestroy {
 
     onItemSelect(itemValue: string) {
         const wasOpen = this.#value() === itemValue;
+
+        // if this item just opened and the click would close it,
+        // ignore the click during the brief protection window
+        const recentlyActivated = this.recentlyActivatedItem();
+        console.log(`${itemValue} was recently opened: ${recentlyActivated}`);
+        console.log(`wasOpen: ${wasOpen}`);
+        if (recentlyActivated === itemValue && wasOpen) {
+            console.log('ignoring click on recently opened item');
+            return;
+        }
+
         const newValue = wasOpen ? '' : itemValue;
 
         // if user is closing an open menu, mark as user-dismissed
@@ -229,8 +244,22 @@ export class RdxNavigationMenuDirective implements OnDestroy {
     }
 
     private setValue(value: string) {
-        // Store previous value before changing
-        this.#previousValue.set(this.#value());
+        console.log('setValue', value);
+        const previousValue = this.#value();
+
+        if (value && value !== previousValue) {
+            this.window.clearTimeout(this.recentlyActivatedTimerRef);
+
+            this.recentlyActivatedItem.set(value);
+
+            this.recentlyActivatedTimerRef = this.window.setTimeout(() => {
+                console.log('clearing recently activated item');
+                this.recentlyActivatedItem.set(null);
+            }, this.clickIgnoreDuration);
+        }
+
+        // store previous value before changing
+        this.#previousValue.set(previousValue);
         this.#value.set(value);
     }
 

--- a/packages/primitives/navigation-menu/src/navigation-menu.directive.ts
+++ b/packages/primitives/navigation-menu/src/navigation-menu.directive.ts
@@ -205,11 +205,7 @@ export class RdxNavigationMenuDirective implements OnDestroy {
 
         // if this item just opened and the click would close it,
         // ignore the click during the brief protection window
-        const recentlyActivated = this.recentlyActivatedItem();
-        console.log(`${itemValue} was recently opened: ${recentlyActivated}`);
-        console.log(`wasOpen: ${wasOpen}`);
-        if (recentlyActivated === itemValue && wasOpen) {
-            console.log('ignoring click on recently opened item');
+        if (this.recentlyActivatedItem() === itemValue && wasOpen) {
             return;
         }
 
@@ -244,7 +240,6 @@ export class RdxNavigationMenuDirective implements OnDestroy {
     }
 
     private setValue(value: string) {
-        console.log('setValue', value);
         const previousValue = this.#value();
 
         if (value && value !== previousValue) {
@@ -253,7 +248,6 @@ export class RdxNavigationMenuDirective implements OnDestroy {
             this.recentlyActivatedItem.set(value);
 
             this.recentlyActivatedTimerRef = this.window.setTimeout(() => {
-                console.log('clearing recently activated item');
                 this.recentlyActivatedItem.set(null);
             }, this.clickIgnoreDuration);
         }

--- a/packages/primitives/navigation-menu/src/navigation-menu.directive.ts
+++ b/packages/primitives/navigation-menu/src/navigation-menu.directive.ts
@@ -70,8 +70,8 @@ export class RdxNavigationMenuDirective implements OnDestroy {
     @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
     @Input() dir: 'ltr' | 'rtl' = 'ltr';
     @Input({ transform: numberAttribute }) delayDuration = 200;
-    @Input({ transform: numberAttribute }) clickIgnoreDuration = 350;
-    @Input({ transform: numberAttribute }) skipDelayDuration = 75;
+    @Input({ transform: numberAttribute }) clickIgnoreDuration = 250;
+    @Input({ transform: numberAttribute }) skipDelayDuration = 200;
     @Input({ transform: booleanAttribute }) loop = false;
     @Input({ transform: booleanAttribute }) cssAnimation = false;
     @Input({ transform: booleanAttribute }) cssOpeningAnimation = false;

--- a/packages/primitives/navigation-menu/src/navigation-menu.directive.ts
+++ b/packages/primitives/navigation-menu/src/navigation-menu.directive.ts
@@ -69,9 +69,9 @@ export class RdxNavigationMenuDirective implements OnDestroy {
 
     @Input() orientation: 'horizontal' | 'vertical' = 'horizontal';
     @Input() dir: 'ltr' | 'rtl' = 'ltr';
-    @Input({ transform: numberAttribute }) delayDuration = 200;
     @Input({ transform: numberAttribute }) clickIgnoreDuration = 250;
-    @Input({ transform: numberAttribute }) skipDelayDuration = 200;
+    @Input({ transform: numberAttribute }) delayDuration = 200;
+    @Input({ transform: numberAttribute }) skipDelayDuration = 300;
     @Input({ transform: booleanAttribute }) loop = false;
     @Input({ transform: booleanAttribute }) cssAnimation = false;
     @Input({ transform: booleanAttribute }) cssOpeningAnimation = false;


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

Added a 250ms grace period to ignore clicks on navigation menu triggers that were recently activated by hover events. This prevents the frustrating UX issue where users hover over a trigger (causing the menu to start opening) and then immediately click on it, which would previously toggle the menu closed. Also added a bit of protection when sliding between different active triggers to prevent the same thing from happening, as I have witnessed users attempting the same thing when sliding between triggers..
