### PR TITLE
docs: add docs for hover card

### DIFF
--- a/apps/radix-docs/src/api-doc/primitives.json
+++ b/apps/radix-docs/src/api-doc/primitives.json
@@ -748,7 +748,140 @@
         }
     },
     "hover-card": {
-        "components": {}
+        "components": {
+            "RdxHoverCardRootDirective": {
+                "description": "",
+                "props": {
+                    "description": "Defines the input properties of the component.",
+                    "values": [
+                        {
+                            "name": "anchor",
+                            "type": "InputSignal<RdxHoverCardAnchorDirective | undefined>",
+                            "defaultValue": "undefined",
+                            "description": "The anchor directive that comes from outside the hover-card rootDirective"
+                        },
+                        {
+                            "name": "defaultOpen",
+                            "type": "InputSignalWithTransform<boolean, BooleanInput>",
+                            "defaultValue": "false",
+                            "description": "The open state of the hover-card when it is initially rendered. Use when you do not need to control its open state."
+                        },
+                        {
+                            "name": "open",
+                            "type": "InputSignalWithTransform<boolean | undefined, BooleanInput>",
+                            "defaultValue": "undefined",
+                            "description": "The controlled state of the hover-card. `open` input takes precedence over `defaultOpen` input."
+                        },
+                        {
+                            "name": "openDelay",
+                            "type": "InputSignalWithTransform<number, NumberInput>",
+                            "defaultValue": "500",
+                            "description": "The delay in milliseconds before the hover-card opens."
+                        },
+                        {
+                            "name": "closeDelay",
+                            "type": "InputSignalWithTransform<number, NumberInput>",
+                            "defaultValue": "200",
+                            "description": "The delay in milliseconds before the hover-card closes."
+                        },
+                        {
+                            "name": "externalControl",
+                            "type": "InputSignalWithTransform<boolean | undefined, BooleanInput>",
+                            "defaultValue": "undefined",
+                            "description": "Whether to control the state of the hover-card from outside. Use in conjunction with `open` input."
+                        },
+                        {
+                            "name": "cssAnimation",
+                            "type": "InputSignalWithTransform<boolean, BooleanInput>",
+                            "defaultValue": "false",
+                            "description": "Whether to take into account CSS opening/closing animations."
+                        },
+                        {
+                            "name": "cssOpeningAnimation",
+                            "type": "InputSignalWithTransform<boolean, BooleanInput>",
+                            "defaultValue": "false",
+                            "description": "Whether to take into account CSS opening animations. `cssAnimation` input must be set to 'true'"
+                        },
+                        {
+                            "name": "cssClosingAnimation",
+                            "type": "InputSignalWithTransform<boolean, BooleanInput>",
+                            "defaultValue": "false",
+                            "description": "Whether to take into account CSS closing animations. `cssAnimation` input must be set to 'true'"
+                        }
+                    ]
+                }
+            },
+            "RdxHoverCardArrowDirective": {
+                "description": "",
+                "props": {
+                    "description": "Defines the input properties of the component.",
+                    "values": [
+                        {
+                            "name": "width",
+                            "type": "InputSignalWithTransform<number, NumberInput>",
+                            "defaultValue": "10",
+                            "description": "The width of the arrow in pixels."
+                        },
+                        {
+                            "name": "height",
+                            "type": "InputSignalWithTransform<number, NumberInput>",
+                            "defaultValue": "5",
+                            "description": "The height of the arrow in pixels."
+                        }
+                    ]
+                }
+            },
+            "RdxHoverCardContentDirective": {
+                "description": "",
+                "props": {
+                    "description": "Defines the input properties of the component.",
+                    "values": [
+                        {
+                            "name": "side",
+                            "type": "InputSignal<RdxPositionSide>",
+                            "defaultValue": "'top'",
+                            "description": "The preferred side of the trigger to render against when open. Will be reversed when collisions occur and avoidCollisions is enabled."
+                        },
+                        {
+                            "name": "sideOffset",
+                            "type": "InputSignalWithTransform<number, NumberInput>",
+                            "defaultValue": "0",
+                            "description": "The distance in pixels from the trigger."
+                        },
+                        {
+                            "name": "align",
+                            "type": "InputSignal<RdxPositionAlign>",
+                            "defaultValue": "'center'",
+                            "description": "The preferred alignment against the trigger. May change when collisions occur."
+                        },
+                        {
+                            "name": "alignOffset",
+                            "type": "InputSignalWithTransform<number, NumberInput>",
+                            "defaultValue": "0",
+                            "description": "An offset in pixels from the \"start\" or \"end\" alignment options."
+                        },
+                        {
+                            "name": "alternatePositionsDisabled",
+                            "type": "InputSignalWithTransform<boolean, BooleanInput>",
+                            "defaultValue": "false",
+                            "description": "Whether to add some alternate positions of the content."
+                        },
+                        {
+                            "name": "onOverlayEscapeKeyDownDisabled",
+                            "type": "InputSignalWithTransform<boolean, BooleanInput>",
+                            "defaultValue": "false",
+                            "description": "Whether to prevent `onOverlayEscapeKeyDown` handler from calling."
+                        },
+                        {
+                            "name": "onOverlayOutsideClickDisabled",
+                            "type": "InputSignalWithTransform<boolean, BooleanInput>",
+                            "defaultValue": "false",
+                            "description": "Whether to prevent `onOverlayOutsideClick` handler from calling."
+                        }
+                    ]
+                }
+            }
+        }
     },
     "hover-card-anchor.directive": {
         "components": {}

--- a/apps/radix-docs/src/components/mdx/KeyboardTable.astro
+++ b/apps/radix-docs/src/components/mdx/KeyboardTable.astro
@@ -22,7 +22,7 @@ const data = attributes || [];
                     return (
                         <tr class="rt-TableRow" style="white-space: nowrap;">
                             <th class="rt-TableCell rt-TableRowHeaderCell">
-                                <kbd class="rounded border border-gray-300 px-1.5 py-0.5 text-xs text-gray-600 shadow-md">
+                                <kbd class="rounded border border-gray-300 px-1.5 py-0.5 text-xs text-gray-600 shadow-md dark:text-gray-300">
                                     {key}
                                 </kbd>
                             </th>

--- a/apps/radix-docs/src/config/docs-config.ts
+++ b/apps/radix-docs/src/config/docs-config.ts
@@ -103,6 +103,7 @@ const docsConfig = {
                         },
                         { name: 'Dialog', url: '/primitives/components/dialog' },
                         { name: 'Dropdown Menu', url: '/primitives/components/dropdown-menu' },
+                        { name: 'Hover Card', url: '/primitives/components/hover-card', label: 'New' },
                         { name: 'Label', url: '/primitives/components/label' },
                         {
                             name: 'Menubar',

--- a/apps/radix-docs/src/content/primitives/components/hover-card.mdx
+++ b/apps/radix-docs/src/content/primitives/components/hover-card.mdx
@@ -1,0 +1,83 @@
+---
+title: Hover Card
+slug: hover-card
+section: components
+description: For sighted users to preview content available behind a link.
+---
+
+# Hover Card
+
+<Description>For sighted users to preview content available behind a link.</Description>
+
+<ComponentPreview name="hover-card" file="hover-card-demo" />
+
+<FeatureList items={[
+    'Can be controlled or uncontrolled.',
+    'Customize side, alignment, offsets, collision handling.',
+    'Optionally render a pointing arrow.',
+    'Supports custom open and close delays.',
+    'Ignored by screen readers.'
+]}/>
+
+## Import
+
+Get started with importing the directives:
+
+```typescript
+import {
+  RdxHoverCardModule
+} from '@radix-ng/primitives/hover-card';
+```
+
+## Anatomy
+
+```html
+<ng-container rdxHoverCardRoot>
+    <button rdxHoverCardTrigger></button>
+
+    <ng-template rdxHoverCardContent>
+        <div rdxHoverCardContentAttributes>
+            <button rdxHoverCardClose></button>
+            Hover Card Content
+            <div rdxHoverCardArrow></div>
+        </div>
+    </ng-template>
+</ng-container>
+```
+## API Reference
+
+### Root
+
+`RdxHoverCardRootDirective`
+
+Contains all the parts of a hover-card.
+
+<PropsTable name="RdxHoverCardRootDirective" />
+
+### Trigger
+
+`RdxHoverCardTriggerDirective`
+
+The button that toggles the hover-card. By default, the `HoverCardContent` will position itself against the trigger.
+
+### Content
+
+`RdxHoverCardContentDirective`
+
+The component that pops out when the hover-card is open.
+
+<PropsTable name="RdxHoverCardContentDirective" />
+
+### Arrow
+
+`RdxHoverCardArrowDirective`
+
+An optional arrow element to render alongside the hover-card. This can be used to help visually link the trigger with the `HoverCardContent`. Must be rendered inside `HoverCardContent`.
+
+<PropsTable name="RdxHoverCardArrowDirective" />
+
+### Close
+
+`RdxHoverCardCloseDirective`
+
+An optional close button element to render alongside the hover-card. This can be used to close the `HoverCardContent`. Must be rendered inside `HoverCardContent`.

--- a/apps/radix-docs/src/demos/primitives/hover-card/hover-card-demo.css
+++ b/apps/radix-docs/src/demos/primitives/hover-card/hover-card-demo.css
@@ -1,0 +1,60 @@
+.HoverCardContent {
+    border-radius: 4px;
+    padding: 20px;
+    width: 300px;
+    background-color: var(--mauve-1);
+    box-shadow:
+        hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
+        hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
+}
+
+.HoverCardContent:focus {
+    box-shadow:
+        hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
+        hsl(206 22% 7% / 20%) 0px 10px 20px -15px,
+        0 0 0 2px var(--violet-7);
+}
+
+.ImageTrigger {
+    cursor: pointer;
+    border-radius: 100%;
+    display: inline-block;
+}
+
+.ImageTrigger:focus {
+    box-shadow: 0 0 0 2px var(--mauve-1);
+}
+
+.Image {
+    display: block;
+    border-radius: 100%;
+}
+
+.Image.normal {
+    width: 45px;
+    height: 45px;
+}
+
+.Image.large {
+    width: 60px;
+    height: 60px;
+}
+
+.Text {
+    margin: 0;
+    color: var(--mauve-12);
+    font-size: 15px;
+    line-height: 1.5;
+}
+
+.Text.bold {
+    font-weight: 700;
+}
+
+.Text.faded {
+    color: var(--mauve-10);
+}
+
+.HoverCardArrow {
+    fill: var(--mauve-1);
+}

--- a/apps/radix-docs/src/demos/primitives/hover-card/hover-card-demo.ts
+++ b/apps/radix-docs/src/demos/primitives/hover-card/hover-card-demo.ts
@@ -1,0 +1,67 @@
+import { Component } from '@angular/core';
+import { RdxHoverCardModule } from '@radix-ng/primitives/hover-card';
+import { LucideAngularModule, X } from 'lucide-angular';
+
+@Component({
+    selector: 'hover-card-demo',
+    standalone: true,
+    imports: [LucideAngularModule, RdxHoverCardModule],
+    styleUrl: 'hover-card-demo.css',
+    template: `
+        <ng-container rdxHoverCardRoot>
+            <a
+                class="ImageTrigger"
+                href="https://twitter.com/radix_ui"
+                target="_blank"
+                rel="noreferrer noopener"
+                rdxHoverCardTrigger
+            >
+                <img
+                    class="Image normal"
+                    src="https://pbs.twimg.com/profile_images/1337055608613253126/r_eiMp2H_400x400.png"
+                    alt="Radix UI"
+                />
+            </a>
+
+            <ng-template rdxHoverCardContent>
+                <div class="HoverCardContent" rdxHoverCardContentAttributes>
+                    <div style="display: flex; flex-direction: column; gap: 7px">
+                        <img
+                            class="Image large"
+                            src="https://pbs.twimg.com/profile_images/1337055608613253126/r_eiMp2H_400x400.png"
+                            alt="Radix UI"
+                        />
+                        <div style="display: flex; flex-direction: column; gap: 15px;">
+                            <div>
+                                <div class="Text bold">Radix</div>
+                                <div class="Text faded">{{ '@radix_ui' }}</div>
+                            </div>
+                            <div class="Text">
+                                Components, icons, colors, and templates for building high-quality, accessible UI. Free
+                                and open-source.
+                            </div>
+                            <div style="display: flex; gap: 15px">
+                                <div style="display: flex; gap: 5px">
+                                    <div class="Text bold">0</div>
+                                    &nbsp;
+                                    <div class="Text faded">Following</div>
+                                </div>
+                                <div style="display: flex; gap: 5px">
+                                    <div class="Text bold">2,900</div>
+                                    &nbsp;
+                                    <div class="Text faded">Followers</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="HoverCardArrow" rdxHoverCardArrow></div>
+                </div>
+            </ng-template>
+        </ng-container>
+    `
+})
+export class HoverCardDemoComponent {
+    protected readonly XIcon = X;
+}
+
+export default HoverCardDemoComponent;

--- a/packages/primitives/hover-card/src/hover-card-content.directive.ts
+++ b/packages/primitives/hover-card/src/hover-card-content.directive.ts
@@ -78,9 +78,13 @@ export class RdxHoverCardContentDirective implements OnInit {
      */
     readonly alternatePositionsDisabled = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
-    /** @description Whether to prevent `onOverlayEscapeKeyDown` handler from calling. */
+    /** @description Whether to prevent `onOverlayEscapeKeyDown` handler from calling.
+     * @default false
+     */
     readonly onOverlayEscapeKeyDownDisabled = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
-    /** @description Whether to prevent `onOverlayOutsideClick` handler from calling. */
+    /** @description Whether to prevent `onOverlayOutsideClick` handler from calling.
+     * @default false
+     */
     readonly onOverlayOutsideClickDisabled = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
 
     /**

--- a/packages/primitives/hover-card/src/hover-card-root.directive.ts
+++ b/packages/primitives/hover-card/src/hover-card-root.directive.ts
@@ -44,7 +44,7 @@ export class RdxHoverCardRootDirective {
     readonly name = computed(() => `rdx-hover-card-root-${this.uniqueId()}`);
 
     /**
-     * @description The anchor directive that comes form outside the hover-card rootDirective
+     * @description The anchor directive that comes from outside the hover-card rootDirective
      * @default undefined
      */
     readonly anchor = input<RdxHoverCardAnchorDirective | undefined>(void 0);
@@ -54,24 +54,26 @@ export class RdxHoverCardRootDirective {
      */
     readonly defaultOpen = input<boolean, BooleanInput>(false, { transform: booleanAttribute });
     /**
-     * @description The controlled state of the hover-card. `open` input take precedence of `defaultOpen` input.
+     * @description The controlled state of the hover-card. `open` input takes precedence over `defaultOpen` input.
      * @default undefined
      */
     readonly open = input<boolean | undefined, BooleanInput>(void 0, { transform: booleanAttribute });
     /**
-     * To customise the open delay for a specific hover-card.
+     * @description The delay in milliseconds before the hover-card opens.
+     * @default 500
      */
     readonly openDelay = input<number, NumberInput>(500, {
         transform: numberAttribute
     });
     /**
-     * To customise the close delay for a specific hover-card.
+     * @description The delay in milliseconds before the hover-card closes.
+     * @default 200
      */
     readonly closeDelay = input<number, NumberInput>(200, {
         transform: numberAttribute
     });
     /**
-     * @description Whether to control the state of the hover-card from external. Use in conjunction with `open` input.
+     * @description Whether to control the state of the hover-card from outside. Use in conjunction with `open` input.
      * @default undefined
      */
     readonly externalControl = input<boolean | undefined, BooleanInput>(void 0, { transform: booleanAttribute });

--- a/packages/primitives/hover-card/stories/hover-card.docs.mdx
+++ b/packages/primitives/hover-card/stories/hover-card.docs.mdx
@@ -58,9 +58,11 @@ import {RdxHoverCardContentAttributesComponent} from "../src/hover-card-content-
 
 ## Features
 
-- ✅ Opens when the trigger is clicked.
-- ✅ Closes when the trigger is clicked again or when pressing escape.
-- ✅ Controllable from outside.
+- ✅ Can be controlled or uncontrolled.
+- ✅ Customize side, alignment, offsets, collision handling.
+- ✅ Optionally render a pointing arrow.
+- ✅ Supports custom open and close delays.
+- ✅ Ignored by screen readers.
 
 ## Anatomy
 


### PR DESCRIPTION
### Description
- Added docs for hover card.
- Fixed/Improved some documentation for hover card inputs.
- Fixed visibility of keyboard component in dark mode.

Completes #340

### Demo
https://www.loom.com/share/ed545631d7b24ace89fada086a60c108