### PR TITLE
fix: update peerDependencies to support Angular 19 and 20

### DIFF
--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -18,8 +18,8 @@
         "headless"
     ],
     "peerDependencies": {
-        "@angular/core": "^19.2.4",
-        "@angular/cdk": "^19.2.7"
+        "@angular/core": "^19.2.0 || ^20.0.0",
+        "@angular/cdk": "^19.2.0 || ^20.0.0"
     },
     "devDependencies": {
         "@angular-devkit/schematics": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,10 +531,10 @@ importers:
   packages/primitives:
     dependencies:
       '@angular/cdk':
-        specifier: ^19.2.7
+        specifier: ^19.2.0 || ^20.0.0
         version: 19.2.7(@angular/common@19.2.4(@angular/core@19.2.4(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@19.2.4(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2)
       '@angular/core':
-        specifier: ^19.2.4
+        specifier: ^19.2.0 || ^20.0.0
         version: 19.2.4(rxjs@7.8.2)(zone.js@0.15.0)
     devDependencies:
       '@angular-devkit/schematics':


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
This PR updates the peerDependency version range for the `primitives` package to be more flexible. As of today, a fresh Angular installation will fail to install `@radix-ng/primitives`. This loosens the dependency range to prevent that from happening.
