### PR TITLE
feat(navigation-menu): add `openOnHover` input trigger to customize toggling the viewport

### DIFF
--- a/packages/primitives/navigation-menu/src/navigation-menu-trigger.directive.ts
+++ b/packages/primitives/navigation-menu/src/navigation-menu-trigger.directive.ts
@@ -54,6 +54,7 @@ export class RdxNavigationMenuTriggerDirective extends RdxNavigationMenuFocusabl
     private readonly viewContainerRef = inject(ViewContainerRef);
 
     readonly disabled = input(false, { transform: booleanAttribute });
+    readonly openOnHover = input(true, { transform: booleanAttribute });
 
     readonly triggerId = makeTriggerId(this.context.baseId, this.item.value());
     readonly contentId = makeContentId(this.context.baseId, this.item.value());
@@ -146,16 +147,18 @@ export class RdxNavigationMenuTriggerDirective extends RdxNavigationMenuFocusabl
     }
 
     onPointerEnter(): void {
-        // ignore if disabled or not the root menu (hover logic primarily for root)
+        // ignore if disabled or not the root menu
         if (this.disabled() || !isRootNavigationMenu(this.context)) return;
 
         this.wasClickClose = false; // Reset click close flag on enter
         this.item.wasEscapeCloseRef.set(false); // Reset escape flag
         this.context.setTriggerPointerState?.(true); // Update context state
 
-        // if the menu isn't already open for this item, trigger the enter logic (handles delays)
+        // if the menu isn't already open for this item, trigger the enter logic
         if (!this.open()) {
-            this.context.onTriggerEnter?.(this.item.value());
+            if (this.openOnHover() || this.context.value() !== '') {
+                this.context.onTriggerEnter?.(this.item.value());
+            }
         }
     }
 


### PR DESCRIPTION


<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

I recently noticed that many of my users struggle to interact with the Navigation Menu in how it assumes you understand you must wait for the viewport to open after hovering over the trigger.

This PR adds a new `openOnHover` input to the `RdxNavigationMenuTriggerDirective` which gives developers a way to toggle the default behavior of the trigger so that it either opens on hover (default) or waits for the user to click the trigger.

Beyond that, all existing functionality is preserved.

<!-- Describe the change you are introducing -->
