### PR TITLE
feat(perf): add performance benchmark suite (Vitest browser mode + CI…

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,35 +45,53 @@ jobs:
       # Benchmark the merge-base in a worktree on the same runner. If the perf app does not exist at
       # the merge-base (bootstrap period) or the base run fails, base.json is simply absent and the
       # comparison falls back to "baseline unavailable" — this step never fails the job.
+      # Every failure mode here (no merge-base, fetch/worktree error, perf app absent at base, base
+      # run produces no report) must degrade to "baseline unavailable" — never fail the job. So git
+      # setup is checked explicitly rather than under `set -e`.
       - name: Benchmark base (merge-base)
         run: |
-          set -e
           BASE_REF="${{ github.base_ref || 'main' }}"
-          git fetch --no-tags origin "$BASE_REF"
-          BASE_SHA="$(git merge-base "origin/$BASE_REF" HEAD)"
+          if ! git fetch --no-tags origin "$BASE_REF"; then
+            echo "::warning::Could not fetch $BASE_REF — baseline unavailable."
+            exit 0
+          fi
+          BASE_SHA="$(git merge-base "origin/$BASE_REF" HEAD || true)"
+          if [ -z "$BASE_SHA" ]; then
+            echo "::warning::No merge-base with $BASE_REF — baseline unavailable."
+            exit 0
+          fi
           echo "Merge-base: $BASE_SHA"
-          git worktree add ../base "$BASE_SHA"
+          if ! git worktree add ../base "$BASE_SHA"; then
+            echo "::warning::Could not create base worktree — baseline unavailable."
+            exit 0
+          fi
 
           if [ ! -d ../base/apps/radix-perf-testing ]; then
             echo "::notice::Perf app absent at merge-base — baseline unavailable."
             exit 0
           fi
 
-          set +e
           (
             cd ../base
             pnpm install --frozen-lockfile
             BENCH_OUTPUT_PATH="$GITHUB_WORKSPACE/base.json" pnpm primitives:bench
-          )
+          ) || echo "::warning::Base benchmark run failed — baseline unavailable."
+
           if [ ! -f "$GITHUB_WORKSPACE/base.json" ]; then
             echo "::warning::Base benchmark did not produce a report — baseline unavailable."
           fi
 
+      # always() so a failed head/base step still posts the report it can (compare.mjs handles a
+      # missing head.json or base.json itself).
       - name: Compare and render report
+        if: always()
         run: node tools/scripts/benchmark/compare.mjs head.json base.json --out benchmark-comment.md
 
+      # continue-on-error: fork PRs get a read-only GITHUB_TOKEN regardless of `permissions`, so the
+      # comment API returns 403 there — that must not turn the (non-blocking) job red.
       - name: Post sticky PR comment
-        if: github.event_name == 'pull_request'
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        continue-on-error: true
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,107 @@
+name: Benchmark
+
+# Per-PR performance comparison (see docs/adr/0009). Benchmarks the PR head and the merge-base on the
+# SAME runner (the primary noise mitigation), diffs them, and posts/updates a sticky PR comment.
+# Informational only — never a required status — until runner variance is characterized.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/primitives/**'
+      - 'apps/radix-perf-testing/**'
+      - 'tools/scripts/benchmark/**'
+      - '.github/workflows/benchmark.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 — we need history to resolve the merge-base for the baseline worktree.
+      - name: Checkout code repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Benchmark head
+        run: BENCH_OUTPUT_PATH="$GITHUB_WORKSPACE/head.json" pnpm primitives:bench
+
+      # Benchmark the merge-base in a worktree on the same runner. If the perf app does not exist at
+      # the merge-base (bootstrap period) or the base run fails, base.json is simply absent and the
+      # comparison falls back to "baseline unavailable" — this step never fails the job.
+      - name: Benchmark base (merge-base)
+        run: |
+          set -e
+          BASE_REF="${{ github.base_ref || 'main' }}"
+          git fetch --no-tags origin "$BASE_REF"
+          BASE_SHA="$(git merge-base "origin/$BASE_REF" HEAD)"
+          echo "Merge-base: $BASE_SHA"
+          git worktree add ../base "$BASE_SHA"
+
+          if [ ! -d ../base/apps/radix-perf-testing ]; then
+            echo "::notice::Perf app absent at merge-base — baseline unavailable."
+            exit 0
+          fi
+
+          set +e
+          (
+            cd ../base
+            pnpm install --frozen-lockfile
+            BENCH_OUTPUT_PATH="$GITHUB_WORKSPACE/base.json" pnpm primitives:bench
+          )
+          if [ ! -f "$GITHUB_WORKSPACE/base.json" ]; then
+            echo "::warning::Base benchmark did not produce a report — baseline unavailable."
+          fi
+
+      - name: Compare and render report
+        run: node tools/scripts/benchmark/compare.mjs head.json base.json --out benchmark-comment.md
+
+      - name: Post sticky PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('benchmark-comment.md', 'utf8');
+            const marker = '<!-- radix-ng-benchmark -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Upload benchmark reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: benchmark-reports
+          path: |
+            head.json
+            base.json
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ node_modules
 /.sass-cache
 /connect.lock
 /coverage
+bench-results.json
+/bench-*.json
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,7 @@ of rediscovering the project conventions from individual stories:
 | Consumer theming | `apps/radix-storybook/docs/overview/theming.docs.mdx` (`Overview/Theming`)                   | Documenting `data-*` state styling, design tokens, or dark mode                                                                                            |
 | Accessibility    | `apps/radix-storybook/docs/overview/accessibility.docs.mdx` (`Overview/Accessibility`)       | Reviewing semantics, labels, keyboard navigation, or focus management                                                                                      |
 | SSR & Hydration  | `apps/radix-storybook/docs/guides/ssr.docs.mdx` (`Guides/Server-Side Rendering`)             | SSR/hydration behavior — stable IDs (`injectId`), platform guards, portal no-op on server, browser-only positioning, hydration-mismatch troubleshooting    |
+| Performance      | `apps/radix-storybook/docs/guides/performance.docs.mdx` (`Guides/Performance`)               | Benchmark suite (`pnpm primitives:bench`, `apps/radix-perf-testing`) — reading the report, writing a bench, the harness; design in `docs/adr/0009`         |
 
 For animation work, distinguish the lifecycle owner before choosing an API:
 

--- a/apps/radix-perf-testing/.eslintrc.json
+++ b/apps/radix-perf-testing/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+    "extends": ["../../.eslintrc.cjs"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts"],
+            "rules": {
+                "@angular-eslint/prefer-standalone": "off"
+            }
+        }
+    ]
+}

--- a/apps/radix-perf-testing/project.json
+++ b/apps/radix-perf-testing/project.json
@@ -1,0 +1,21 @@
+{
+    "name": "radix-perf-testing",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "projectType": "application",
+    "prefix": "app",
+    "sourceRoot": "apps/radix-perf-testing/src",
+    "tags": [],
+    "targets": {
+        "bench": {
+            "executor": "@nx/vitest:test",
+            "cache": false,
+            "options": {
+                "configFile": "apps/radix-perf-testing/vite.config.mts",
+                "watch": false
+            }
+        },
+        "lint": {
+            "executor": "@nx/eslint:lint"
+        }
+    }
+}

--- a/apps/radix-perf-testing/src/harness/benchmark.ts
+++ b/apps/radix-perf-testing/src/harness/benchmark.ts
@@ -48,6 +48,9 @@ let sentinelSeq = 0;
 async function runIteration<T>(scenario: BenchScenario<T>): Promise<Sample> {
     const handle = await createMount(scenario.component);
     const id = `bench-sentinel-${sentinelSeq++}`;
+    // Captured so it can be removed in the finally: sentinels left in document.body accumulate
+    // across iterations, inflating later paint/layout samples (the metric corrupts itself).
+    let sentinel: HTMLElement | undefined;
 
     try {
         if (scenario.interact) {
@@ -60,7 +63,7 @@ async function runIteration<T>(scenario: BenchScenario<T>): Promise<Sample> {
             const rendersBefore = handle.renderCount();
             const paintPromise = observePaint(id);
             const t0 = performance.now();
-            appendSentinel(id);
+            sentinel = appendSentinel(id);
             scenario.interact(handle.instance);
             handle.tick();
             const t1 = performance.now();
@@ -77,7 +80,7 @@ async function runIteration<T>(scenario: BenchScenario<T>): Promise<Sample> {
         scenario.prepare?.(handle.instance);
         const paintPromise = observePaint(id);
         const t0 = performance.now();
-        appendSentinel(id);
+        sentinel = appendSentinel(id);
         handle.attach();
         handle.tick();
         const t1 = performance.now();
@@ -89,6 +92,7 @@ async function runIteration<T>(scenario: BenchScenario<T>): Promise<Sample> {
             renders: handle.renderCount()
         };
     } finally {
+        sentinel?.remove();
         handle.destroy();
     }
 }

--- a/apps/radix-perf-testing/src/harness/benchmark.ts
+++ b/apps/radix-perf-testing/src/harness/benchmark.ts
@@ -1,0 +1,140 @@
+import { Type } from '@angular/core';
+import { appendSentinel, computeStats, mode, nextPaint, observePaint, Stats } from './metrics';
+import { createMount } from './mount';
+
+export interface BenchmarkOptions {
+    /** Measured iterations (default 20). */
+    runs?: number;
+    /** Warmup iterations discarded before measuring (default 10). */
+    warmupRuns?: number;
+}
+
+/**
+ * One benchmark scenario.
+ *
+ * - No `interact`  → the harness measures the **mount** (create N components + tick + paint).
+ * - With `interact` → the harness mounts untimed, then measures the **interaction** (mutate signals
+ *   + tick + paint). Use for re-render scenarios like "toggle 500 checkboxes" or "open the popup".
+ */
+export interface BenchScenario<T> {
+    /** Standalone root component mounted once per iteration. */
+    component: Type<T>;
+    /** Configure the instance before the mount tick (e.g. set item count). Untimed for mount runs. */
+    prepare?: (instance: T) => void;
+    /** Mutate the instance to trigger the measured re-render. Presence switches to interaction mode. */
+    interact?: (instance: T) => void;
+}
+
+export type BenchSetup<T> = () => BenchScenario<T>;
+
+export interface BenchmarkResult {
+    name: string;
+    /** Synchronous CPU cost of the measured section (ms). */
+    duration: Stats;
+    /** Deterministic CD-cycle count for the measured section. */
+    renders: number;
+    /** Time from section start until the sentinel paints (ms), or null if Element Timing never fired. */
+    paint: Stats | null;
+}
+
+interface Sample {
+    duration: number;
+    paint: number | null;
+    renders: number;
+}
+
+let sentinelSeq = 0;
+
+async function runIteration<T>(scenario: BenchScenario<T>): Promise<Sample> {
+    const handle = await createMount(scenario.component);
+    const id = `bench-sentinel-${sentinelSeq++}`;
+
+    try {
+        if (scenario.interact) {
+            // Mount fully and let it paint — this work is NOT part of the interaction sample.
+            scenario.prepare?.(handle.instance);
+            handle.attach();
+            handle.tick();
+            await nextPaint();
+
+            const rendersBefore = handle.renderCount();
+            const paintPromise = observePaint(id);
+            const t0 = performance.now();
+            appendSentinel(id);
+            scenario.interact(handle.instance);
+            handle.tick();
+            const t1 = performance.now();
+            const paintAbs = await paintPromise;
+
+            return {
+                duration: t1 - t0,
+                paint: paintAbs === null ? null : paintAbs - t0,
+                renders: handle.renderCount() - rendersBefore
+            };
+        }
+
+        // Mount mode: time create-view-attach + tick + paint.
+        scenario.prepare?.(handle.instance);
+        const paintPromise = observePaint(id);
+        const t0 = performance.now();
+        appendSentinel(id);
+        handle.attach();
+        handle.tick();
+        const t1 = performance.now();
+        const paintAbs = await paintPromise;
+
+        return {
+            duration: t1 - t0,
+            paint: paintAbs === null ? null : paintAbs - t0,
+            renders: handle.renderCount()
+        };
+    } finally {
+        handle.destroy();
+    }
+}
+
+/**
+ * Run a scenario warmup + measured times, IQR-filter the samples, and return the result row.
+ * The caller collects rows into a local array and flushes them via the reporter in afterAll —
+ * NOTE: Vitest browser mode does not isolate module state between bench files, so the harness
+ * deliberately keeps no shared results array (that leaked rows across files). One call = one row.
+ */
+export async function benchmark<T>(
+    name: string,
+    setup: BenchSetup<T>,
+    options?: BenchmarkOptions
+): Promise<BenchmarkResult> {
+    const runs = options?.runs ?? 20;
+    const warmupRuns = options?.warmupRuns ?? 10;
+
+    const durations: number[] = [];
+    const paints: number[] = [];
+    const renderCounts: number[] = [];
+
+    for (let i = 0; i < warmupRuns + runs; i++) {
+        const sample = await runIteration(setup());
+        if (i < warmupRuns) {
+            continue;
+        }
+        durations.push(sample.duration);
+        renderCounts.push(sample.renders);
+        if (sample.paint !== null) {
+            paints.push(sample.paint);
+        }
+    }
+
+    const uniqueRenders = new Set(renderCounts);
+    if (uniqueRenders.size > 1) {
+        console.warn(`[bench] "${name}" render count is not deterministic: ${[...uniqueRenders].sort().join(', ')}`);
+    }
+    if (paints.length === 0) {
+        console.warn(`[bench] "${name}" produced no Element Timing paint entries — paint metric omitted.`);
+    }
+
+    return {
+        name,
+        duration: computeStats(durations),
+        renders: mode(renderCounts),
+        paint: paints.length ? computeStats(paints) : null
+    };
+}

--- a/apps/radix-perf-testing/src/harness/metrics.ts
+++ b/apps/radix-perf-testing/src/harness/metrics.ts
@@ -1,0 +1,118 @@
+/** IQR-filtered summary of a sample set (ms). Mirrors base-ui's mean ± stdDev report shape. */
+export interface Stats {
+    median: number;
+    mean: number;
+    stdDev: number;
+    min: number;
+    max: number;
+    samples: number;
+    outliersRemoved: number;
+}
+
+/** Linear-interpolation quantile over an already-sorted ascending array. */
+function quantile(sorted: number[], q: number): number {
+    if (sorted.length === 1) {
+        return sorted[0];
+    }
+    const pos = (sorted.length - 1) * q;
+    const base = Math.floor(pos);
+    const rest = pos - base;
+    const next = sorted[base + 1];
+    return next !== undefined ? sorted[base] + rest * (next - sorted[base]) : sorted[base];
+}
+
+/**
+ * Drop outliers outside the Tukey fence [Q1 - 1.5·IQR, Q3 + 1.5·IQR], then summarize. If filtering
+ * would remove everything (degenerate input), fall back to the raw samples.
+ */
+export function computeStats(raw: number[]): Stats {
+    const sorted = [...raw].sort((a, b) => a - b);
+    const q1 = quantile(sorted, 0.25);
+    const q3 = quantile(sorted, 0.75);
+    const iqr = q3 - q1;
+    const lo = q1 - 1.5 * iqr;
+    const hi = q3 + 1.5 * iqr;
+    const filtered = sorted.filter((v) => v >= lo && v <= hi);
+    const use = filtered.length ? filtered : sorted;
+
+    const mean = use.reduce((a, b) => a + b, 0) / use.length;
+    const variance = use.reduce((a, b) => a + (b - mean) ** 2, 0) / use.length;
+
+    return {
+        median: quantile(use, 0.5),
+        mean,
+        stdDev: Math.sqrt(variance),
+        min: use[0],
+        max: use[use.length - 1],
+        samples: use.length,
+        outliersRemoved: raw.length - use.length
+    };
+}
+
+/** Most frequent value in a list (used for the deterministic renders count). */
+export function mode(values: number[]): number {
+    const counts = new Map<number, number>();
+    let best = values[0];
+    let bestCount = 0;
+    for (const v of values) {
+        const c = (counts.get(v) ?? 0) + 1;
+        counts.set(v, c);
+        if (c > bestCount) {
+            bestCount = c;
+            best = v;
+        }
+    }
+    return best;
+}
+
+const SENTINEL_STYLE = 'position:fixed;top:0;left:0;font-size:1px;opacity:0.01;pointer-events:none;';
+
+/**
+ * Append the harness's own Element Timing sentinel. Element Timing only reports an element that
+ * intersects the viewport and carries text/image content (see docs/adr/0009 risk 2), hence the
+ * tiny on-screen text node rather than a hidden/off-screen one. Returns the element for cleanup.
+ */
+export function appendSentinel(identifier: string): HTMLElement {
+    const sentinel = document.createElement('div');
+    sentinel.setAttribute('elementtiming', identifier);
+    sentinel.textContent = '.';
+    sentinel.style.cssText = SENTINEL_STYLE;
+    document.body.appendChild(sentinel);
+    return sentinel;
+}
+
+/**
+ * Resolve with the absolute paint time (from `performance.timeOrigin`, comparable to
+ * `performance.now()`) of the sentinel with the given identifier, or null if no paint entry arrives
+ * within `timeoutMs` (caller then falls back / records a missing paint).
+ */
+export function observePaint(identifier: string, timeoutMs = 2000): Promise<number | null> {
+    return new Promise<number | null>((resolve) => {
+        let settled = false;
+        const observer = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+                if ((entry as PerformanceEntry & { identifier?: string }).identifier === identifier) {
+                    settled = true;
+                    observer.disconnect();
+                    resolve(entry.startTime);
+                    return;
+                }
+            }
+        });
+        observer.observe({ type: 'element', buffered: true } as PerformanceObserverInit);
+
+        setTimeout(() => {
+            if (!settled) {
+                observer.disconnect();
+                resolve(null);
+            }
+        }, timeoutMs);
+    });
+}
+
+/** Resolve after the browser has painted at least one frame (double rAF). */
+export function nextPaint(): Promise<void> {
+    return new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+}

--- a/apps/radix-perf-testing/src/harness/mount.ts
+++ b/apps/radix-perf-testing/src/harness/mount.ts
@@ -1,0 +1,76 @@
+// Partially-compiled primitives fall back to JIT under createApplication() — load the compiler first
+// (see docs/adr/0009 + radix-ssr-testing). This must be the first import the harness pulls in.
+import '@angular/compiler';
+import {
+    afterEveryRender,
+    ApplicationRef,
+    ComponentRef,
+    createComponent,
+    EnvironmentInjector,
+    provideZonelessChangeDetection,
+    Type
+} from '@angular/core';
+import { createApplication } from '@angular/platform-browser';
+
+/**
+ * A freshly bootstrapped, zoneless application hosting a single standalone root component.
+ * One of these is created and destroyed per benchmark iteration so nothing leaks between samples.
+ */
+export interface MountHandle<T> {
+    readonly appRef: ApplicationRef;
+    readonly componentRef: ComponentRef<T>;
+    readonly instance: T;
+    readonly host: HTMLElement;
+    /** CD-cycle proxy: number of render passes since mount (afterRender fires once per pass). */
+    renderCount(): number;
+    /** Attach the component view to the app (untimed in callers that want to time only the tick). */
+    attach(): void;
+    /** Synchronous change detection + render. */
+    tick(): void;
+    destroy(): void;
+}
+
+/**
+ * Create a host element, a zoneless application, and the root component — WITHOUT attaching/ticking
+ * yet, so the caller controls exactly which work falls inside the timed window.
+ */
+export async function createMount<T>(component: Type<T>): Promise<MountHandle<T>> {
+    const host = document.createElement('div');
+    host.setAttribute('data-bench-host', '');
+    document.body.appendChild(host);
+
+    const appRef = await createApplication({
+        providers: [provideZonelessChangeDetection()]
+    });
+
+    let renders = 0;
+    // afterEveryRender runs once per render pass in the browser — our framework-native "renders"
+    // proxy (the analog of base-ui's React.Profiler commit count).
+    const renderHook = afterEveryRender(
+        () => {
+            renders += 1;
+        },
+        { injector: appRef.injector }
+    );
+
+    const componentRef = createComponent(component, {
+        environmentInjector: appRef.injector as EnvironmentInjector,
+        hostElement: host
+    });
+
+    return {
+        appRef,
+        componentRef,
+        instance: componentRef.instance,
+        host,
+        renderCount: () => renders,
+        attach: () => appRef.attachView(componentRef.hostView),
+        tick: () => appRef.tick(),
+        destroy: () => {
+            renderHook.destroy();
+            componentRef.destroy();
+            appRef.destroy();
+            host.remove();
+        }
+    };
+}

--- a/apps/radix-perf-testing/src/harness/reporter.ts
+++ b/apps/radix-perf-testing/src/harness/reporter.ts
@@ -1,0 +1,17 @@
+import { commands } from 'vitest/browser';
+import { BenchmarkResult } from './benchmark';
+
+// Custom browser command registered in vite.config.mts. It runs in Node (has fs access) and
+// accumulates rows across all bench files in the run, writing BENCH_OUTPUT_PATH each time.
+interface BenchCommands {
+    writeBenchResults(file: string, results: BenchmarkResult[]): Promise<string>;
+}
+
+/**
+ * Flush this file's results to the JSON output (BENCH_OUTPUT_PATH, default bench-results.json).
+ * Call from each bench file's afterAll. Tagged with the source file so multiple bench files merge
+ * cleanly into one report. Tests run with fileParallelism:false, so writes never race.
+ */
+export async function writeResults(file: string, results: readonly BenchmarkResult[]): Promise<void> {
+    await (commands as unknown as BenchCommands).writeBenchResults(file, [...results]);
+}

--- a/apps/radix-perf-testing/src/harness/setup-compiler.ts
+++ b/apps/radix-perf-testing/src/harness/setup-compiler.ts
@@ -1,0 +1,4 @@
+// Loaded via test.setupFiles before any bench module is imported. Primitives are partially compiled
+// and fall back to JIT under createApplication(), so the compiler must be present before any
+// primitive/platform code evaluates its static initializers (see docs/adr/0009 risk + radix-ssr-testing).
+import '@angular/compiler';

--- a/apps/radix-perf-testing/src/tests/checkbox.bench.ts
+++ b/apps/radix-perf-testing/src/tests/checkbox.bench.ts
@@ -1,0 +1,62 @@
+import { Component, signal } from '@angular/core';
+import { RdxCheckboxButtonDirective, RdxCheckboxRootDirective } from '@radix-ng/primitives/checkbox';
+import { afterAll, describe, expect, it } from 'vitest';
+import { benchmark, BenchmarkResult } from '../harness/benchmark';
+import { writeResults } from '../harness/reporter';
+
+const FILE = 'checkbox.bench.ts';
+const COUNT = 500;
+
+// Headless scenario: a row of N checkboxes. No styles — paint cost tracks DOM size, which is the
+// point. `allChecked` is one-way bound into every checkbox so toggling it forces all N to re-render.
+@Component({
+    selector: 'checkbox-list',
+    standalone: true,
+    imports: [RdxCheckboxRootDirective, RdxCheckboxButtonDirective],
+    template: `
+        @for (item of items(); track item) {
+            <button [checked]="allChecked()" rdxCheckboxRoot rdxCheckboxButton type="button">·</button>
+        }
+    `
+})
+class CheckboxList {
+    readonly items = signal<number[]>([]);
+    readonly allChecked = signal(false);
+
+    setCount(n: number): void {
+        this.items.set(Array.from({ length: n }, (_, i) => i));
+    }
+
+    toggleAll(): void {
+        this.allChecked.update((v) => !v);
+    }
+}
+
+describe('Checkbox', () => {
+    const rows: BenchmarkResult[] = [];
+
+    afterAll(async () => {
+        await writeResults(FILE, rows);
+    });
+
+    it(`mount (${COUNT} instances)`, async () => {
+        const result = await benchmark<CheckboxList>(`Checkbox mount (${COUNT} instances)`, () => ({
+            component: CheckboxList,
+            prepare: (instance) => instance.setCount(COUNT)
+        }));
+        rows.push(result);
+
+        expect(result.duration.median).toBeGreaterThan(0);
+    });
+
+    it(`toggle (${COUNT} instances)`, async () => {
+        const result = await benchmark<CheckboxList>(`Checkbox toggle (${COUNT} instances)`, () => ({
+            component: CheckboxList,
+            prepare: (instance) => instance.setCount(COUNT),
+            interact: (instance) => instance.toggleAll()
+        }));
+        rows.push(result);
+
+        expect(result.duration.median).toBeGreaterThan(0);
+    });
+});

--- a/apps/radix-perf-testing/src/tests/select.bench.ts
+++ b/apps/radix-perf-testing/src/tests/select.bench.ts
@@ -18,7 +18,10 @@ import { benchmark, BenchmarkResult } from '../harness/benchmark';
 import { writeResults } from '../harness/reporter';
 
 const FILE = 'select.bench.ts';
-const COUNT = 1000;
+// 50 = typical real-world list (the common path); 1000 = non-virtualized worst case (stresses the
+// collection + popper + portal machinery). Track both so a regression in the common path is visible
+// separately from the stress case.
+const COUNTS = [50, 1000];
 
 // Highest-risk path: opening a Select renders all options through the collection (DOM-order
 // contentChildren), the portal, and the popper positioner at once. Mounted closed is cheap; the
@@ -88,14 +91,16 @@ describe('Select', () => {
         await writeResults(FILE, rows);
     });
 
-    it(`open (${COUNT} options)`, async () => {
-        const result = await benchmark<SelectOpen>(`Select open (${COUNT} options)`, () => ({
-            component: SelectOpen,
-            prepare: (instance) => instance.setCount(COUNT),
-            interact: (instance) => instance.open()
-        }));
-        rows.push(result);
+    for (const count of COUNTS) {
+        it(`open (${count} options)`, async () => {
+            const result = await benchmark<SelectOpen>(`Select open (${count} options)`, () => ({
+                component: SelectOpen,
+                prepare: (instance) => instance.setCount(count),
+                interact: (instance) => instance.open()
+            }));
+            rows.push(result);
 
-        expect(result.duration.median).toBeGreaterThan(0);
-    });
+            expect(result.duration.median).toBeGreaterThan(0);
+        });
+    }
 });

--- a/apps/radix-perf-testing/src/tests/select.bench.ts
+++ b/apps/radix-perf-testing/src/tests/select.bench.ts
@@ -1,0 +1,101 @@
+import { Component, signal } from '@angular/core';
+import {
+    RdxSelectGroup,
+    RdxSelectItem,
+    RdxSelectItemText,
+    RdxSelectList,
+    RdxSelectPopup,
+    RdxSelectPortal,
+    RdxSelectPortalPresence,
+    RdxSelectPositioner,
+    RdxSelectPositionerContent,
+    RdxSelectRoot,
+    RdxSelectTrigger,
+    RdxSelectValue
+} from '@radix-ng/primitives/select';
+import { afterAll, describe, expect, it } from 'vitest';
+import { benchmark, BenchmarkResult } from '../harness/benchmark';
+import { writeResults } from '../harness/reporter';
+
+const FILE = 'select.bench.ts';
+const COUNT = 1000;
+
+// Highest-risk path: opening a Select renders all options through the collection (DOM-order
+// contentChildren), the portal, and the popper positioner at once. Mounted closed is cheap; the
+// measured interaction is the open. No styles — we track the machinery + DOM cost, not CSS.
+@Component({
+    selector: 'select-open',
+    standalone: true,
+    imports: [
+        RdxSelectRoot,
+        RdxSelectTrigger,
+        RdxSelectValue,
+        RdxSelectPortal,
+        RdxSelectPortalPresence,
+        RdxSelectPopup,
+        RdxSelectPositioner,
+        RdxSelectPositionerContent,
+        RdxSelectList,
+        RdxSelectGroup,
+        RdxSelectItem,
+        RdxSelectItemText
+    ],
+    template: `
+        <ng-container [open]="isOpen()" rdxSelectRoot>
+            <button rdxSelectTrigger type="button" aria-label="options">
+                <span rdxSelectValue placeholder="Pick…"></span>
+            </button>
+
+            <div rdxSelectPortal>
+                <ng-template rdxSelectPortalPresence>
+                    <div rdxSelectPopup>
+                        <div rdxSelectPositioner>
+                            <div rdxSelectPositionerContent>
+                                <div rdxSelectList>
+                                    <div rdxSelectGroup>
+                                        @for (option of options(); track option) {
+                                            <div [value]="option" rdxSelectItem>
+                                                <span rdxSelectItemText>{{ option }}</span>
+                                            </div>
+                                        }
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </ng-template>
+            </div>
+        </ng-container>
+    `
+})
+class SelectOpen {
+    readonly isOpen = signal(false);
+    readonly options = signal<string[]>([]);
+
+    setCount(n: number): void {
+        this.options.set(Array.from({ length: n }, (_, i) => `Option ${i}`));
+    }
+
+    open(): void {
+        this.isOpen.set(true);
+    }
+}
+
+describe('Select', () => {
+    const rows: BenchmarkResult[] = [];
+
+    afterAll(async () => {
+        await writeResults(FILE, rows);
+    });
+
+    it(`open (${COUNT} options)`, async () => {
+        const result = await benchmark<SelectOpen>(`Select open (${COUNT} options)`, () => ({
+            component: SelectOpen,
+            prepare: (instance) => instance.setCount(COUNT),
+            interact: (instance) => instance.open()
+        }));
+        rows.push(result);
+
+        expect(result.duration.median).toBeGreaterThan(0);
+    });
+});

--- a/apps/radix-perf-testing/tsconfig.json
+++ b/apps/radix-perf-testing/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "target": "es2022",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitOverride": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "module": "preserve",
+        "moduleResolution": "bundler",
+        "lib": ["dom", "es2022"],
+        "types": ["vitest/globals", "node"]
+    },
+    "files": [],
+    "include": ["src/**/*.ts"],
+    "extends": "../../tsconfig.base.json",
+    "angularCompilerOptions": {
+        "strictInjectionParameters": true,
+        "strictInputAccessModifiers": true,
+        "strictTemplates": true
+    }
+}

--- a/apps/radix-perf-testing/tsconfig.spec.json
+++ b/apps/radix-perf-testing/tsconfig.spec.json
@@ -1,0 +1,13 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "preserve",
+        "target": "es2022",
+        "types": ["vitest/globals", "node"],
+        "moduleResolution": "bundler",
+        "isolatedModules": true
+    },
+    "files": ["vite.config.mts"],
+    "include": ["src/**/*.bench.ts", "src/**/*.ts", "src/**/*.d.ts"]
+}

--- a/apps/radix-perf-testing/vite.config.mts
+++ b/apps/radix-perf-testing/vite.config.mts
@@ -1,0 +1,82 @@
+import angular from '@analogjs/vite-plugin-angular';
+import { playwright } from '@vitest/browser-playwright';
+import { writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+const root = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(root, '../..');
+
+// Node-side accumulator: each bench file flushes its rows here; we merge by source file (tests run
+// with fileParallelism:false, so no races) and rewrite BENCH_OUTPUT_PATH on every flush.
+interface BenchStats {
+    median: number;
+    mean: number;
+    stdDev: number;
+    min: number;
+    max: number;
+    samples: number;
+    outliersRemoved: number;
+}
+interface BenchRow {
+    name: string;
+    duration: BenchStats;
+    renders: number;
+    paint: BenchStats | null;
+}
+
+const collected = new Map<string, BenchRow[]>();
+
+const ms = (n: number): string => `${n.toFixed(1)}ms`;
+
+/** Print the rows a bench file just produced as a readable table to the real terminal. */
+function printRows(file: string, rows: BenchRow[]): void {
+    const lines = rows.map((r) => {
+        const dur = `${ms(r.duration.median).padStart(8)} ±${r.duration.stdDev.toFixed(1)}`;
+        const paint = r.paint ? ms(r.paint.median).padStart(8) : '       —';
+        const dropped = r.duration.outliersRemoved ? ` (-${r.duration.outliersRemoved} outlier)` : '';
+        return `    ${r.name.padEnd(32)} duration ${dur.padEnd(14)} paint ${paint}  renders ${r.renders}  n=${r.duration.samples}${dropped}`;
+    });
+    console.log(`\n  📊 ${file}\n${lines.join('\n')}\n`);
+}
+
+function writeBenchResults(_ctx: unknown, file: string, results: BenchRow[]): string {
+    collected.set(file, results);
+    printRows(file, results);
+    const merged = [...collected.values()].flat();
+    const out = process.env.BENCH_OUTPUT_PATH ?? 'bench-results.json';
+    const target = isAbsolute(out) ? out : resolve(workspaceRoot, out);
+    writeFileSync(target, `${JSON.stringify(merged, null, 2)}\n`);
+    return target;
+}
+
+// Performance benchmark runner — see docs/adr/0009.
+// Runs in a real Chromium browser via Vitest Browser Mode (Playwright provider) so we get
+// real layout/paint. This is intentionally NOT the jsdom/zoneless test-setup used by the
+// primitives spec suite — each bench bootstraps a real application via createApplication().
+export default defineConfig({
+    root,
+    cacheDir: '../../node_modules/.vitest/apps/radix-perf-testing',
+    plugins: [angular(), tsconfigPaths()],
+    // Pre-bundle deps that primitives pull in, so the browser runner doesn't reload mid-run when one
+    // is first imported (reloads make Vitest warn and can skew the first samples).
+    optimizeDeps: {
+        include: ['@angular/compiler', '@floating-ui/dom']
+    },
+    test: {
+        include: ['src/tests/**/*.bench.ts'],
+        // Load the JIT compiler before any bench module imports a partially-compiled primitive.
+        setupFiles: ['./src/harness/setup-compiler.ts'],
+        // benchmarks are sequential by nature — one file at a time, no parallelism
+        fileParallelism: false,
+        browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [{ browser: 'chromium' }],
+            commands: { writeBenchResults }
+        }
+    }
+});

--- a/apps/radix-storybook/docs/guides/performance.docs.mdx
+++ b/apps/radix-storybook/docs/guides/performance.docs.mdx
@@ -1,0 +1,136 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Guides/Performance" />
+
+# Performance Benchmarks
+
+How Radix NG measures the runtime cost of its primitives, and how to read the numbers.
+
+The library ships a benchmark suite that mounts and exercises primitives in a **real Chromium browser**
+and reports mount time, re-render time, paint time, and change-detection cycle counts. It exists to
+catch performance regressions per pull request — the same way [Base UI](https://base-ui.com/) does — so
+a change that doubles the cost of rendering 500 checkboxes is visible before it ships.
+
+It is **not** part of the normal test run. Benchmarks are noisy and slow by nature, so they live in a
+dedicated project with their own target.
+
+## Running the benchmarks
+
+```bash
+pnpm primitives:bench
+```
+
+This runs every `*.bench.ts` file in `apps/radix-perf-testing` and prints a table:
+
+```
+  📊 select.bench.ts
+    Select open (1000 options)       duration   49.4ms ±2.5  paint   52.8ms  renders 7  n=19 (-1 outlier)
+  📊 checkbox.bench.ts
+    Checkbox mount (500 instances)   duration   18.0ms ±1.8  paint   25.4ms  renders 1  n=20
+    Checkbox toggle (500 instances)  duration   11.1ms ±0.5  paint   14.7ms  renders 1  n=19 (-1 outlier)
+```
+
+To also save a machine-readable report (used by CI to diff against the base branch):
+
+```bash
+BENCH_OUTPUT_PATH=head.json pnpm primitives:bench
+```
+
+## Reading a row
+
+```
+Checkbox mount (500 instances)   duration   18.0ms ±1.8  paint   25.4ms  renders 1  n=20
+```
+
+| Column         | What it is                                                                                  | How to read it                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **duration**   | Pure **JS/CPU time** of the measured section (create 500 components + one change detection), median of the measured runs | The work that blocks the main thread. This is the primary regression signal.                            |
+| **±1.8**       | Standard deviation of that median (ms)                                                       | The noise. The smaller it is, the more you can trust the number.                                         |
+| **paint**      | Time from section start until the browser **actually paints** the frame (Element Timing API) | Always ≥ duration — it adds layout + paint on top of the JS. `paint − duration` is the browser render cost. |
+| **renders**    | Number of change-detection passes during the section                                        | Deterministic. A jump here (e.g. 1 → 2) almost always means an extra, avoidable CD cycle.                |
+| **n=20** / **(-1 outlier)** | Samples kept after IQR outlier removal (out of 20 measured runs, after 10 warmup runs) | `-1 outlier` means one run was discarded as a statistical outlier. Normal.                               |
+
+### What good looks like
+
+The numbers above are healthy. Concretely:
+
+- **`renders 1`** for both mount and toggle is ideal — mounting _and_ re-rendering 500 checkboxes each
+  collapse into a **single** change-detection pass. Seeing `2`–`3` on a simple primitive is a red flag:
+  something triggers redundant CD (e.g. a signal written during change detection).
+- **`toggle` (11 ms) is cheaper than `mount` (18 ms)** — expected, because the components already exist
+  and only re-render. If a toggle were _more_ expensive than the mount, the re-render is doing too much.
+- **`paint ≈ duration + ~7 ms`** — a healthy gap. If paint were several times the duration, the
+  bottleneck is in the DOM/layout, not in Angular.
+- **small `±stdDev`** (here 4–10% of the median) — the measurement is stable enough to trust.
+
+`renders 7` for `Select open` is also fine: opening a popup legitimately runs several passes
+(transition status → portal presence → positioner → Floating UI). It is deterministic; a jump to a
+two-digit count would be worth investigating.
+
+### What to watch for
+
+Absolute numbers depend on the machine — their real purpose is **PR-vs-base comparison on the same
+runner**. Rules of thumb:
+
+- **`duration` up by more than ~20%** vs the base branch → likely a regression (this is the noise
+  threshold the comparison uses).
+- **`renders` changed** (e.g. 1 → 2) → almost always a real bug, even if `duration` barely moved: a CD
+  cycle was added.
+- **large `±stdDev`** (> ~25% of the median) → the test is too noisy to trust that run; ignore the delta.
+- **`paint` grew while `duration` did not** → a regression in DOM/styles rather than in logic.
+
+As a rough scale for a headless primitive: mounting 500 instances in ~15–20 ms and re-rendering in
+~10 ms is cheap and healthy. Hundreds of milliseconds, or a two-digit `renders` count on a simple
+primitive, is worth digging into.
+
+## How a benchmark is written
+
+A bench file mounts a tiny, **unstyled** scenario component (headless — paint cost should track DOM
+size, not CSS) and calls `benchmark()`. No `interact` measures the **mount**; an `interact` callback
+measures a **re-render** (the mount becomes untimed warmup).
+
+```ts
+import { benchmark, BenchmarkResult } from '../harness/benchmark';
+import { writeResults } from '../harness/reporter';
+
+describe('Checkbox', () => {
+  const rows: BenchmarkResult[] = [];
+  afterAll(async () => writeResults('checkbox.bench.ts', rows));
+
+  it('mount (500 instances)', async () => {
+    const result = await benchmark('Checkbox mount (500 instances)', () => ({
+      component: CheckboxList,
+      prepare: (instance) => instance.setCount(500) // configure before the timed mount
+    }));
+    rows.push(result);
+    expect(result.duration.median).toBeGreaterThan(0);
+  });
+
+  it('toggle (500 instances)', async () => {
+    const result = await benchmark('Checkbox toggle (500 instances)', () => ({
+      component: CheckboxList,
+      prepare: (instance) => instance.setCount(500),
+      interact: (instance) => instance.toggleAll() // ← presence switches to re-render mode
+    }));
+    rows.push(result);
+    expect(result.duration.median).toBeGreaterThan(0);
+  });
+});
+```
+
+The harness runs 10 warmup + 20 measured iterations, drops outliers with a Tukey (1.5·IQR) fence, and
+reports the median, standard deviation, and a deterministic render count.
+
+## How it works under the hood
+
+- **Real browser.** Benchmarks run under **Vitest Browser Mode (Playwright/Chromium)**, not jsdom, so
+  layout and paint are real. Each iteration bootstraps a fresh zoneless application with
+  `createApplication()` and tears it down, so nothing leaks between samples.
+- **Paint** is captured with the [Element Timing API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceElementTiming):
+  the harness appends a tiny on-screen sentinel element and observes when the browser paints it.
+- **Renders** are counted with `afterEveryRender` registered on the app injector — the framework-native
+  analog of Base UI's `React.Profiler` commit count.
+
+The design, trade-offs, and the planned CI comparison (diff PR vs the merge-base, post a sticky comment
+like Base UI's `▼ -41%` / "within noise" table) are documented in
+`docs/adr/0009-performance-benchmarks-vitest-browser-mode.md`.

--- a/docs/adr/0009-performance-benchmarks-vitest-browser-mode.md
+++ b/docs/adr/0009-performance-benchmarks-vitest-browser-mode.md
@@ -1,6 +1,6 @@
 # ADR 0009: Performance Benchmarks via Vitest Browser Mode (base-ui–style harness, Angular-native metrics)
 
-- Status: Proposed
+- Status: Accepted — Phases 1 (spike), 2 (harness + pilots) & 3 (CI) done; Phase 4 (more primitives / blocking thresholds) later
 - Date: 2026-06-12
 - Decision owners: Radix NG maintainers
 - Related: new project `apps/radix-perf-testing` (consumers: all primitives; pilot: `checkbox`, `select`), `.github/workflows/`, `tools/scripts/benchmark/`
@@ -122,32 +122,42 @@ tools/scripts/benchmark/
 ```ts
 // apps/radix-perf-testing/vite.config.mts
 import angular from '@analogjs/vite-plugin-angular';
+import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [angular(), tsconfigPaths()],
+  // Pre-bundle the JIT compiler so the browser runner doesn't reload mid-run on first import.
+  optimizeDeps: { include: ['@angular/compiler'] },
   test: {
     include: ['src/tests/**/*.bench.ts'],
+    fileParallelism: false, // benchmarks are sequential — one file at a time
     browser: {
       enabled: true,
-      provider: 'playwright',
+      provider: playwright(), // Vitest 4: provider is a factory, not the string 'playwright'
       headless: true,
       instances: [{ browser: 'chromium' }]
-    },
-    // benchmarks are sequential by nature — one file at a time, no parallelism
-    fileParallelism: false
+    }
   }
 });
 ```
 
-Notes:
+Notes (validated by the Phase 1 spike):
 
 - **Do not reuse `packages/primitives/test-setup.ts`** — it initializes the jsdom/TestBed
   environment. The perf app bootstraps real applications via `createApplication` instead.
+- **Vitest 4 needs the `@vitest/browser-playwright` package** and a `playwright()` provider factory
+  (the `provider: 'playwright'` string form was removed). Keep `@vitest/browser`,
+  `@vitest/browser-playwright`, and `vitest` on the **exact same version** (the spike hit a hard
+  "mixed versions" failure between 4.1.7 and 4.1.8 — all are pinned to 4.1.8).
+- **Every bench file (or a shared setup) must `import '@angular/compiler';` first** — primitives are
+  partially compiled and fall back to JIT under `createApplication()`, exactly like
+  `radix-ssr-testing`. Without it: `_PlatformLocation needs to be compiled using the JIT compiler`.
 - `*.bench.ts` files use plain `it()`/`describe()` from Vitest (as base-ui does — their `.bench.tsx`
   files are regular browser-mode tests, the "bench" is the helper, not Vitest bench mode), so the
-  `include` pattern above keeps them out of every other project's `**/*.spec.ts` globs.
+  `include` pattern above keeps them out of every other project's `**/*.spec.ts` globs. The project
+  exposes only `bench` + `lint` targets (no `test`), so CI's `test`/`build` sweeps skip it.
 - The suite stays **zoneless**: `provideZonelessChangeDetection()` in every bootstrapped app.
 
 ### Harness API
@@ -185,24 +195,44 @@ Per iteration:
    stabilization + a fresh sentinel paint).
 4. Destroy the `ApplicationRef`, remove the host element, `performance.clearMarks()`.
 
-After all iterations: drop outliers outside `[Q1 - 1.5·IQR, Q3 + 1.5·IQR]`, compute stats, append to
-the in-memory result list. A Vitest `afterAll`/reporter hook writes the full
-`BenchmarkResult[]` JSON to `process.env.BENCH_OUTPUT_PATH ?? 'bench-results.json'`.
+After all iterations: drop outliers outside `[Q1 - 1.5·IQR, Q3 + 1.5·IQR]`, compute stats, and
+**return** the `BenchmarkResult` (one `benchmark()` call = one row). The bench file collects rows in a
+local array and flushes them in `afterAll`.
 
-**Renders metric**: wrap `ApplicationRef.tick` (or subscribe to a counter incremented in an
-`afterRender` callback registered on the app injector) and report the count per iteration. It must be
-deterministic; the harness should warn if the count varies across runs. `ɵsetProfiler`-based template
-profiling is explicitly out of scope for v1 (private API; revisit only if CD-cycle counts prove too
-coarse).
+> **Gotcha (Phase 2):** Vitest Browser Mode does **not** isolate module state between bench files —
+> they share one page/module graph. A module-level results array therefore leaks rows across files
+> (the first file's rows reappear under the next file's output). The harness keeps **no** shared
+> state: `benchmark()` returns its row; the file owns the array. Do not reintroduce a global collector.
+
+**Reporter**: writing a file from the browser isn't possible directly, so the JSON write goes through
+a **custom Vitest browser command** registered in `vite.config.mts` under `browser.commands` (runs in
+Node). The browser side imports `commands` from **`vitest/browser`** (not the deprecated
+`@vitest/browser/context`) and calls `commands.writeBenchResults(file, rows)`. The Node command
+accumulates rows by source file, writes `process.env.BENCH_OUTPUT_PATH ?? 'bench-results.json'`, **and
+prints a readable table to the terminal** on each flush (the `@nx/vitest:test` executor otherwise
+swallows per-test output, so a plain run shows only "Successfully ran" — the command's `console.log`
+surfaces alongside vite's logs). `bench-results.json` / `bench-*.json` are gitignored.
+
+**Renders metric**: count render passes via **`afterEveryRender`** (Angular 21 renamed `afterRender`
+→ `afterEveryRender`) registered on the app injector, reported per iteration. It must be deterministic
+(checkbox mount/toggle = 1; select open = 7, stable); the harness warns if the count varies across
+runs. `ɵsetProfiler`-based template profiling is out of scope for v1 (private API; revisit only if
+CD-cycle counts prove too coarse).
 
 ### Pilot bench files
 
-- `checkbox.bench.ts`:
-  - `Checkbox mount (500 instances)` — direct analog of base-ui's test;
-  - `Checkbox toggle (500 instances)` — interaction: flip all `checked` signals, one CD pass expected.
-- `select.bench.ts`:
-  - `Select open (1000 options)` — mount closed, interaction opens the popup; this covers collection
-    (DOM-order `contentChildren`), popper positioning, and portal cost — our highest-risk path.
+- `checkbox.bench.ts` — **done**:
+  - `Checkbox mount (500 instances)` — direct analog of base-ui's test (~17 ms, renders 1);
+  - `Checkbox toggle (500 instances)` — interaction: flip a shared `[checked]` signal bound into all
+    N, one CD pass (~11 ms, renders 1).
+- `select.bench.ts` — **done**:
+  - `Select open (1000 options)` — mount closed (`[open]` bound to a signal), interaction sets it
+    true; covers collection (DOM-order `contentChildren`), popper positioning, and portal cost — our
+    highest-risk path (~49 ms, renders 7 — the open path runs multiple CD passes, deterministically).
+
+Local stability (Phase 2 acceptance): within a run stdDev is ~4% of the median; run-to-run medians
+vary ~10–14% on a busy dev machine — under base-ui's ±20% noise threshold and the reason same-runner
+head/base comparison (not absolute thresholds) is the CI design.
 
 Scenario components live next to the bench files, are standalone, and use **no styles** (headless —
 paint cost is dominated by DOM size, which is exactly what we want to track).
@@ -267,30 +297,44 @@ Negative / accepted costs:
 
 ## Risks and open questions
 
-1. **AnalogJS Angular plugin under Vitest Browser Mode** — the main technical risk; it is known to
-   work in jsdom and in Storybook's Vite pipeline, but browser mode must be verified first.
-   **Mitigation / go-no-go**: phase 1 is a spike that mounts one Checkbox in browser mode before any
-   harness work. Fallback if it fails: precompile scenarios with a small Vite build (the Storybook
-   builder path) — decided only if needed.
-2. **Element Timing in headless Chromium** — paints do occur in headless mode, but the observer
-   wiring must be verified in the spike. The entry type `element` requires the `elementtiming`
-   attribute on a rendered, non-`display:none` element — the harness appends a 1×1 transparent
-   sentinel element itself (scenario components don't need to know about it), positioned offscreen
-   rather than hidden.
+1. **AnalogJS Angular plugin under Vitest Browser Mode** — **resolved by the spike: it works.**
+   `createApplication()` + `createComponent()` mounts 500 real `rdxCheckboxRoot` primitives in
+   Chromium with correct `role`/`aria-checked` and non-zero layout. The only requirement is the
+   `@angular/compiler` JIT import noted above. No precompile fallback needed.
+2. **Element Timing in headless Chromium** — **resolved by the spike: it fires.** The `element`
+   entry requires the `elementtiming` attribute on a rendered element that **intersects the viewport
+   and contains text or an image** — an empty, `display:none`, or fully off-screen element does
+   _not_ report. The harness therefore appends its own sentinel as a tiny on-screen text node
+   (`position:fixed; top:0; left:0; font-size:1px; opacity:0.01; textContent:'.'`), filtering
+   `PerformanceObserver` `element` entries by `entry.identifier === 'bench-sentinel'`. Scenario
+   components don't need to know about it. (Earlier draft said "1×1 transparent, off-screen" — that
+   would not report; corrected here.)
 3. **Runner variance** — collect ~2 weeks of runs before considering making the check blocking or
    alerting on it.
 
 ## Rollout plan (implementation phases)
 
-1. **Spike (go/no-go)**: `apps/radix-perf-testing` skeleton + browser-mode config + one trivial test
-   mounting `RdxCheckboxRootDirective`-based component and observing a sentinel `element` timing
-   entry. Verifies risks 1 and 2.
-2. **Harness + pilots**: `benchmark()` with warmup/runs/IQR, CD-cycle counter, JSON reporter;
-   `checkbox.bench.ts` and `select.bench.ts`; `primitives:bench` script; local numbers reviewed for
-   stability (run 5× locally, compare medians).
-3. **CI**: `benchmark.yml`, `compare.mjs`, sticky comment, noise thresholds; non-blocking.
+1. **Spike (go/no-go) — ✅ DONE (go).** `apps/radix-perf-testing` skeleton + browser-mode config + a
+   throwaway `spike.bench.ts` that mounted 500 `rdxCheckboxRoot` components and observed the sentinel
+   `element` timing entry. Both risks resolved (see Risks 1 & 2); the spike file was then **removed**
+   (the real `checkbox.bench.ts` now covers mount + Element Timing). Established facts now baked into
+   the config above: `@vitest/browser-playwright` + `playwright()` factory, all `@vitest/*` pinned to
+   4.1.8, `import '@angular/compiler'` required, sentinel must be on-screen text.
+2. **Harness + pilots — ✅ DONE.** `benchmark()` with warmup(10)/runs(20)/IQR in
+   `src/harness/{benchmark,metrics,mount,reporter}.ts`; `afterEveryRender` render counter; Element
+   Timing paint; JSON reporter via a `vitest/browser` command that also prints a terminal table;
+   `checkbox.bench.ts` (mount + toggle) and `select.bench.ts` (open 1000); `primitives:bench` script.
+   Local medians reviewed for stability (within-run ~4%, run-to-run ~10–14%).
+3. **CI — ✅ DONE.** `.github/workflows/benchmark.yml` (paths-triggered + `workflow_dispatch`,
+   pinned actions) benchmarks head, then the merge-base in a `git worktree` on the **same runner**,
+   and runs `tools/scripts/benchmark/compare.mjs`. The script ports base-ui's `compareBenchmarkReports.ts`
+   rules (±20% noise, regression/improvement/within-noise, simple-sum totals) and renders a compact
+   sticky PR comment (significant tests in the table, within-noise ones collapsed) + the full table in
+   the job summary; reports upload as artifacts. Handles `new` / `removed` tests and
+   `baseline unavailable` (perf app absent at merge-base, or base run failed). Sticky comment via
+   `actions/github-script` (find-by-marker, update-or-create). **Non-blocking** (informational status).
 4. **Later (separate decisions)**: more primitives (Autocomplete virtualized, Menu, Slider drag),
-   profiler-hook render timings, blocking thresholds, historical tracking.
+   profiler-hook render timings, blocking thresholds once variance is known, historical tracking.
 
 ## References
 

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         "@types/node": "^22.19.19",
         "@typescript-eslint/utils": "^8.60.1",
         "@vitest/browser": "4.1.8",
-        "@vitest/browser-playwright": "^4.1.8",
+        "@vitest/browser-playwright": "4.1.8",
         "@vitest/coverage-v8": "4.1.8",
         "@vitest/ui": "4.1.8",
         "angular-eslint": "^21.3.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "primitives:build": "nx run primitives:build",
         "primitives:build:schematics": "nx run primitives:build:schematics",
         "primitives:test": "nx run primitives:test",
+        "primitives:bench": "nx run radix-perf-testing:bench",
         "primitives:ssr:serve": "nx serve radix-ssr-testing",
         "primitives:ssr:build": "nx build radix-ssr-testing",
         "primitives:ssr:dist": "node dist/apps/radix-ssr-testing/server/server.mjs",
@@ -122,8 +123,10 @@
         "@types/jest-axe": "^3.5.9",
         "@types/node": "^22.19.19",
         "@typescript-eslint/utils": "^8.60.1",
-        "@vitest/coverage-v8": "4.1.7",
-        "@vitest/ui": "4.1.7",
+        "@vitest/browser": "4.1.8",
+        "@vitest/browser-playwright": "^4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "angular-eslint": "^21.3.1",
         "autoprefixer": "^10.4.21",
         "chromatic": "^11.27.0",
@@ -171,7 +174,7 @@
         "verdaccio": "6.7.2",
         "vite": "7.1.5",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "4.1.7"
+        "vitest": "4.1.8"
     },
     "nx": {
         "includedScripts": []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,13 +77,13 @@ importers:
     devDependencies:
       '@analogjs/storybook-angular':
         specifier: ^2.5.2
-        version: 2.5.3(@analogjs/vite-plugin-angular@2.1.3(@angular-devkit/build-angular@21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4))(@angular/build@21.2.9(388f4330983cc9846a9970149fe71723)))(@storybook/angular@10.4.1(11caa08e2c4605fc4c5ad8e17af988e4))(esbuild@0.19.12)(rollup@4.61.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 2.5.3(@analogjs/vite-plugin-angular@2.1.3(@angular-devkit/build-angular@21.2.9(4cc3ab656cb840e277f06c6833a72048))(@angular/build@21.2.9(d6c73b17cf1bdc531fce60a9b6b07260)))(@storybook/angular@10.4.1(5ed5fa0a0020b2c75547640e46966b47))(esbuild@0.19.12)(rollup@4.61.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))
       '@analogjs/vite-plugin-angular':
         specifier: 2.1.3
-        version: 2.1.3(@angular-devkit/build-angular@21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4))(@angular/build@21.2.9(388f4330983cc9846a9970149fe71723))
+        version: 2.1.3(@angular-devkit/build-angular@21.2.9(4cc3ab656cb840e277f06c6833a72048))(@angular/build@21.2.9(d6c73b17cf1bdc531fce60a9b6b07260))
       '@angular-devkit/build-angular':
         specifier: 21.2.9
-        version: 21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4)
+        version: 21.2.9(4cc3ab656cb840e277f06c6833a72048)
       '@angular-devkit/core':
         specifier: 21.2.9
         version: 21.2.9(chokidar@5.0.0)
@@ -92,7 +92,7 @@ importers:
         version: 21.2.9(chokidar@5.0.0)
       '@angular/build':
         specifier: 21.2.9
-        version: 21.2.9(388f4330983cc9846a9970149fe71723)
+        version: 21.2.9(d6c73b17cf1bdc531fce60a9b6b07260)
       '@angular/cli':
         specifier: 21.2.12
         version: 21.2.12(@types/node@22.19.19)(chokidar@5.0.0)
@@ -137,7 +137,7 @@ importers:
         version: 1.17.0(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
       '@nx/angular':
         specifier: 22.7.5
-        version: 22.7.5(a106eaf856f794ee3ac776f2da8d17d8)
+        version: 22.7.5(baca9dca2f1c013684ab123a108f0515)
       '@nx/devkit':
         specifier: 22.7.5
         version: 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
@@ -155,16 +155,16 @@ importers:
         version: 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(eslint@10.4.1(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/storybook':
         specifier: 22.7.5
-        version: 22.7.5(23797dcc60f54bd6d406e761a6a92ef1)
+        version: 22.7.5(5a6adf055d56b6f0fc47a9ff50d017ea)
       '@nx/vite':
         specifier: 22.7.5
-        version: 22.7.5(05420544d9d5b7a5760d8a5e0fdd0f0e)
+        version: 22.7.5(12086cbca555034a40c9aeb1591368f7)
       '@nx/vitest':
         specifier: 22.7.5
-        version: 22.7.5(05420544d9d5b7a5760d8a5e0fdd0f0e)
+        version: 22.7.5(12086cbca555034a40c9aeb1591368f7)
       '@nx/web':
         specifier: 22.7.5
-        version: 22.7.5(e0e07c13dc6d3bdec3871f55668cf109)
+        version: 22.7.5(e1104a4a719209e99305d7eb66db814e)
       '@nx/workspace':
         specifier: 22.7.5
         version: 22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))
@@ -185,7 +185,7 @@ importers:
         version: 10.4.1(@types/react@19.2.16)(esbuild@0.19.12)(rollup@4.61.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/angular':
         specifier: 10.4.1
-        version: 10.4.1(11caa08e2c4605fc4c5ad8e17af988e4)
+        version: 10.4.1(5ed5fa0a0020b2c75547640e46966b47)
       '@swc-node/register':
         specifier: 1.11.1
         version: 1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2)
@@ -225,12 +225,18 @@ importers:
       '@typescript-eslint/utils':
         specifier: ^8.60.1
         version: 8.60.1(eslint@10.4.1(jiti@2.4.2))(typescript@5.9.2)
+      '@vitest/browser':
+        specifier: 4.1.8
+        version: 4.1.8(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.8
+        version: 4.1.8(playwright@1.60.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8':
-        specifier: 4.1.7
-        version: 4.1.7(vitest@4.1.7)
+        specifier: 4.1.8
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       '@vitest/ui':
-        specifier: 4.1.7
-        version: 4.1.7(vitest@4.1.7)
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       angular-eslint:
         specifier: ^21.3.1
         version: 21.4.0(@angular/cli@21.2.12(@types/node@22.19.19)(chokidar@5.0.0))(chokidar@5.0.0)(eslint@10.4.1(jiti@2.4.2))(typescript-eslint@8.60.1(eslint@10.4.1(jiti@2.4.2))(typescript@5.9.2))(typescript@5.9.2)
@@ -373,8 +379,8 @@ importers:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.2)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
       vitest:
-        specifier: 4.1.7
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
 
   apps/radix-docs:
     dependencies:
@@ -383,7 +389,7 @@ importers:
         version: 3.15.12
       '@analogjs/astro-angular':
         specifier: 2.5.3
-        version: 2.5.3(d7bfbf60ee5a66b74422faff2f0e1e4c)
+        version: 2.5.3(cc57d93604905e029a00ffca93d17a64)
       '@astrojs/alpinejs':
         specifier: ^0.5.0
         version: 0.5.0(@types/alpinejs@3.13.11)(alpinejs@3.15.12)
@@ -1778,6 +1784,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -6714,11 +6723,22 @@ packages:
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0
 
-  '@vitest/coverage-v8@4.1.7':
-    resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
+  '@vitest/browser-playwright@4.1.8':
+    resolution: {integrity: sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==}
     peerDependencies:
-      '@vitest/browser': 4.1.7
-      vitest: 4.1.7
+      playwright: '*'
+      vitest: 4.1.8
+
+  '@vitest/browser@4.1.8':
+    resolution: {integrity: sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==}
+    peerDependencies:
+      vitest: 4.1.8
+
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -6726,11 +6746,11 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/expect@4.1.7':
-    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@4.1.7':
-    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -6743,31 +6763,31 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/pretty-format@4.1.7':
-    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@4.1.7':
-    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@4.1.7':
-    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/spy@4.1.7':
-    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/ui@4.1.7':
-    resolution: {integrity: sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw==}
+  '@vitest/ui@4.1.8':
+    resolution: {integrity: sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA==}
     peerDependencies:
-      vitest: 4.1.7
+      vitest: 4.1.8
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@vitest/utils@4.1.7':
-    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -11566,6 +11586,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
   polka@0.5.2:
     resolution: {integrity: sha512-FVg3vDmCqP80tOrs+OeNlgXYmFppTXdjD5E7I4ET1NjvtNmQrb1/mJibybKkb/d4NA7YWAr1ojxuhpL3FHqdlw==}
 
@@ -14234,20 +14258,20 @@ packages:
       vite:
         optional: true
 
-  vitest@4.1.7:
-    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.7
-      '@vitest/browser-preview': 4.1.7
-      '@vitest/browser-webdriverio': 4.1.7
-      '@vitest/coverage-istanbul': 4.1.7
-      '@vitest/coverage-v8': 4.1.7
-      '@vitest/ui': 4.1.7
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -14954,11 +14978,11 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/astro-angular@2.5.3(d7bfbf60ee5a66b74422faff2f0e1e4c)':
+  '@analogjs/astro-angular@2.5.3(cc57d93604905e029a00ffca93d17a64)':
     dependencies:
-      '@analogjs/vite-plugin-angular': 2.5.3(@angular-devkit/build-angular@21.2.9(691bfca5a052675126ab87e45387bdfa))(@angular/build@21.2.9(4c003e0d7e0197f0bf2c31c6819848eb))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      '@analogjs/vite-plugin-angular': 2.5.3(@angular-devkit/build-angular@21.2.9(2edb92a56ee9e52aab6a731c1295fc65))(@angular/build@21.2.9(6cd8ec108fad5399587a0de9daf15df9))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
       '@angular/animations': 21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
-      '@angular/build': 21.2.9(4c003e0d7e0197f0bf2c31c6819848eb)
+      '@angular/build': 21.2.9(6cd8ec108fad5399587a0de9daf15df9)
       '@angular/common': 21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/compiler': 21.2.9
       '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3)
@@ -14975,10 +14999,10 @@ snapshots:
       - '@emnapi/runtime'
       - vite
 
-  '@analogjs/storybook-angular@2.5.3(@analogjs/vite-plugin-angular@2.1.3(@angular-devkit/build-angular@21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4))(@angular/build@21.2.9(388f4330983cc9846a9970149fe71723)))(@storybook/angular@10.4.1(11caa08e2c4605fc4c5ad8e17af988e4))(esbuild@0.19.12)(rollup@4.61.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))':
+  '@analogjs/storybook-angular@2.5.3(@analogjs/vite-plugin-angular@2.1.3(@angular-devkit/build-angular@21.2.9(4cc3ab656cb840e277f06c6833a72048))(@angular/build@21.2.9(d6c73b17cf1bdc531fce60a9b6b07260)))(@storybook/angular@10.4.1(5ed5fa0a0020b2c75547640e46966b47))(esbuild@0.19.12)(rollup@4.61.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))':
     dependencies:
-      '@analogjs/vite-plugin-angular': 2.1.3(@angular-devkit/build-angular@21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4))(@angular/build@21.2.9(388f4330983cc9846a9970149fe71723))
-      '@storybook/angular': 10.4.1(11caa08e2c4605fc4c5ad8e17af988e4)
+      '@analogjs/vite-plugin-angular': 2.1.3(@angular-devkit/build-angular@21.2.9(4cc3ab656cb840e277f06c6833a72048))(@angular/build@21.2.9(d6c73b17cf1bdc531fce60a9b6b07260))
+      '@storybook/angular': 10.4.1(5ed5fa0a0020b2c75547640e46966b47)
       '@storybook/builder-vite': 10.4.1(esbuild@0.19.12)(rollup@4.61.0)(storybook@10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       vite: 7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
@@ -14987,14 +15011,14 @@ snapshots:
       - rollup
       - webpack
 
-  '@analogjs/vite-plugin-angular@2.1.3(@angular-devkit/build-angular@21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4))(@angular/build@21.2.9(388f4330983cc9846a9970149fe71723))':
+  '@analogjs/vite-plugin-angular@2.1.3(@angular-devkit/build-angular@21.2.9(4cc3ab656cb840e277f06c6833a72048))(@angular/build@21.2.9(d6c73b17cf1bdc531fce60a9b6b07260))':
     dependencies:
       ts-morph: 21.0.1
     optionalDependencies:
-      '@angular-devkit/build-angular': 21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4)
-      '@angular/build': 21.2.9(388f4330983cc9846a9970149fe71723)
+      '@angular-devkit/build-angular': 21.2.9(4cc3ab656cb840e277f06c6833a72048)
+      '@angular/build': 21.2.9(d6c73b17cf1bdc531fce60a9b6b07260)
 
-  '@analogjs/vite-plugin-angular@2.5.3(@angular-devkit/build-angular@21.2.9(691bfca5a052675126ab87e45387bdfa))(@angular/build@21.2.9(4c003e0d7e0197f0bf2c31c6819848eb))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@analogjs/vite-plugin-angular@2.5.3(@angular-devkit/build-angular@21.2.9(2edb92a56ee9e52aab6a731c1295fc65))(@angular/build@21.2.9(6cd8ec108fad5399587a0de9daf15df9))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       magic-string: 0.30.21
       obug: 2.1.1
@@ -15002,8 +15026,8 @@ snapshots:
       tinyglobby: 0.2.17
       ts-morph: 21.0.1
     optionalDependencies:
-      '@angular-devkit/build-angular': 21.2.9(691bfca5a052675126ab87e45387bdfa)
-      '@angular/build': 21.2.9(4c003e0d7e0197f0bf2c31c6819848eb)
+      '@angular-devkit/build-angular': 21.2.9(2edb92a56ee9e52aab6a731c1295fc65)
+      '@angular/build': 21.2.9(6cd8ec108fad5399587a0de9daf15df9)
       vite: 7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -15030,13 +15054,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@21.2.9(691bfca5a052675126ab87e45387bdfa)':
+  '@angular-devkit/build-angular@21.2.9(2edb92a56ee9e52aab6a731c1295fc65)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
       '@angular-devkit/build-webpack': 0.2102.9(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.12)))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.12))
       '@angular-devkit/core': 21.2.9(chokidar@5.0.0)
-      '@angular/build': 21.2.9(9ed069c323fd89898be00c76aca8d671)
+      '@angular/build': 21.2.9(f050b634be0e939d334b3e0e7ec140c4)
       '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3)
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -15130,13 +15154,13 @@ snapshots:
       - yaml
     optional: true
 
-  '@angular-devkit/build-angular@21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4)':
+  '@angular-devkit/build-angular@21.2.9(4cc3ab656cb840e277f06c6833a72048)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
       '@angular-devkit/build-webpack': 0.2102.9(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.12)))(webpack@5.105.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.12))
       '@angular-devkit/core': 21.2.9(chokidar@5.0.0)
-      '@angular/build': 21.2.9(49f91bedf6488ef39ce5e59900b71427)
+      '@angular/build': 21.2.9(e032493e132c0ecb31997dc986dc1335)
       '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2)
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -15382,125 +15406,7 @@ snapshots:
       '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
       tslib: 2.8.1
 
-  '@angular/build@21.2.9(388f4330983cc9846a9970149fe71723)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
-      '@angular/compiler': 21.2.9
-      '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2)
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.19)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0))
-      beasties: 0.4.1
-      browserslist: 4.28.2
-      esbuild: 0.27.3
-      https-proxy-agent: 7.0.6
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      listr2: 9.0.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 8.0.0
-      picomatch: 4.0.4
-      piscina: 5.1.4
-      rolldown: 1.0.0-rc.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      sass: 1.97.3
-      semver: 7.7.4
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.15
-      tslib: 2.8.1
-      typescript: 5.9.2
-      undici: 7.24.4
-      vite: 7.3.2(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0)
-      watchpack: 2.5.1
-    optionalDependencies:
-      '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 21.2.9(@angular/animations@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
-      '@angular/platform-server': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/animations@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
-      '@angular/ssr': 21.2.9(78d46de19b9295408e578b7334f06151)
-      less: 4.6.4
-      lmdb: 3.5.1
-      ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2))(tailwindcss@4.3.0)(tslib@2.8.1)(typescript@5.9.2)
-      postcss: 8.5.15
-      tailwindcss: 4.3.0
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  '@angular/build@21.2.9(49f91bedf6488ef39ce5e59900b71427)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
-      '@angular/compiler': 21.2.9
-      '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2)
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.19)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@22.19.19)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.9.0))
-      beasties: 0.4.1
-      browserslist: 4.28.2
-      esbuild: 0.27.3
-      https-proxy-agent: 7.0.6
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      listr2: 9.0.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 8.0.0
-      picomatch: 4.0.4
-      piscina: 5.1.4
-      rolldown: 1.0.0-rc.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      sass: 1.97.3
-      semver: 7.7.4
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.15
-      tslib: 2.8.1
-      typescript: 5.9.2
-      undici: 7.24.4
-      vite: 7.3.2(@types/node@22.19.19)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.9.0)
-      watchpack: 2.5.1
-    optionalDependencies:
-      '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/platform-browser': 21.2.9(@angular/animations@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
-      '@angular/platform-server': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/animations@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
-      '@angular/ssr': 21.2.9(78d46de19b9295408e578b7334f06151)
-      less: 4.4.2
-      lmdb: 3.5.1
-      ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2))(tailwindcss@4.3.0)(tslib@2.8.1)(typescript@5.9.2)
-      postcss: 8.5.12
-      tailwindcss: 4.3.0
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  '@angular/build@21.2.9(4c003e0d7e0197f0bf2c31c6819848eb)':
+  '@angular/build@21.2.9(6cd8ec108fad5399587a0de9daf15df9)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
@@ -15543,7 +15449,7 @@ snapshots:
       ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.3.0)(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.15
       tailwindcss: 4.3.0
-      vitest: 4.1.7(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -15559,7 +15465,125 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.2.9(9ed069c323fd89898be00c76aca8d671)':
+  '@angular/build@21.2.9(d6c73b17cf1bdc531fce60a9b6b07260)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
+      '@angular/compiler': 21.2.9
+      '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.19)
+      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0))
+      beasties: 0.4.1
+      browserslist: 4.28.2
+      esbuild: 0.27.3
+      https-proxy-agent: 7.0.6
+      istanbul-lib-instrument: 6.0.3
+      jsonc-parser: 3.3.1
+      listr2: 9.0.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      parse5-html-rewriting-stream: 8.0.0
+      picomatch: 4.0.4
+      piscina: 5.1.4
+      rolldown: 1.0.0-rc.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      sass: 1.97.3
+      semver: 7.7.4
+      source-map-support: 0.5.21
+      tinyglobby: 0.2.15
+      tslib: 2.8.1
+      typescript: 5.9.2
+      undici: 7.24.4
+      vite: 7.3.2(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0)
+      watchpack: 2.5.1
+    optionalDependencies:
+      '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
+      '@angular/platform-browser': 21.2.9(@angular/animations@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-server': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/animations@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/ssr': 21.2.9(78d46de19b9295408e578b7334f06151)
+      less: 4.6.4
+      lmdb: 3.5.1
+      ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2))(tailwindcss@4.3.0)(tslib@2.8.1)(typescript@5.9.2)
+      postcss: 8.5.15
+      tailwindcss: 4.3.0
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@types/node'
+      - chokidar
+      - jiti
+      - lightningcss
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  '@angular/build@21.2.9(e032493e132c0ecb31997dc986dc1335)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
+      '@angular/compiler': 21.2.9
+      '@angular/compiler-cli': 21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.19)
+      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.2(@types/node@22.19.19)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.9.0))
+      beasties: 0.4.1
+      browserslist: 4.28.2
+      esbuild: 0.27.3
+      https-proxy-agent: 7.0.6
+      istanbul-lib-instrument: 6.0.3
+      jsonc-parser: 3.3.1
+      listr2: 9.0.5
+      magic-string: 0.30.21
+      mrmime: 2.0.1
+      parse5-html-rewriting-stream: 8.0.0
+      picomatch: 4.0.4
+      piscina: 5.1.4
+      rolldown: 1.0.0-rc.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      sass: 1.97.3
+      semver: 7.7.4
+      source-map-support: 0.5.21
+      tinyglobby: 0.2.15
+      tslib: 2.8.1
+      typescript: 5.9.2
+      undici: 7.24.4
+      vite: 7.3.2(@types/node@22.19.19)(jiti@2.4.2)(less@4.4.2)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.9.0)
+      watchpack: 2.5.1
+    optionalDependencies:
+      '@angular/core': 21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)
+      '@angular/platform-browser': 21.2.9(@angular/animations@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))
+      '@angular/platform-server': 21.2.9(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@21.2.9)(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@21.2.9(@angular/animations@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
+      '@angular/ssr': 21.2.9(78d46de19b9295408e578b7334f06151)
+      less: 4.4.2
+      lmdb: 3.5.1
+      ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2))(tailwindcss@4.3.0)(tslib@2.8.1)(typescript@5.9.2)
+      postcss: 8.5.12
+      tailwindcss: 4.3.0
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@types/node'
+      - chokidar
+      - jiti
+      - lightningcss
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  '@angular/build@21.2.9(f050b634be0e939d334b3e0e7ec140c4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2102.9(chokidar@5.0.0)
@@ -15602,7 +15626,7 @@ snapshots:
       ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.3))(tailwindcss@4.3.0)(tslib@2.8.1)(typescript@5.9.3)
       postcss: 8.5.12
       tailwindcss: 4.3.0
-      vitest: 4.1.7(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -17846,6 +17870,8 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@blazediff/core@1.9.1': {}
+
   '@borewit/text-codec@0.2.2': {}
 
   '@bufbuild/protobuf@2.12.0': {}
@@ -19900,16 +19926,16 @@ snapshots:
       node-gyp: 12.3.0
       proc-log: 6.1.0
 
-  '@nx/angular@22.7.5(a106eaf856f794ee3ac776f2da8d17d8)':
+  '@nx/angular@22.7.5(baca9dca2f1c013684ab123a108f0515)':
     dependencies:
       '@angular-devkit/core': 21.2.9(chokidar@5.0.0)
       '@angular-devkit/schematics': 21.2.9(chokidar@5.0.0)
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
       '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0)))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/module-federation': 22.7.5(7e9f33a4a4e1f118e3a7649156592283)
-      '@nx/rspack': 22.7.5(5249932e09750214990eea39f5c6f939)
-      '@nx/web': 22.7.5(e0e07c13dc6d3bdec3871f55668cf109)
+      '@nx/module-federation': 22.7.5(54f57d94210f4c17056c0e5cef0ce967)
+      '@nx/rspack': 22.7.5(7d47a8ddc1a47da98e3b3ca8831e3464)
+      '@nx/web': 22.7.5(e1104a4a719209e99305d7eb66db814e)
       '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(html-webpack-plugin@5.6.7(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15)))(lightningcss@1.32.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/workspace': 22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.2)
@@ -19924,8 +19950,8 @@ snapshots:
       tslib: 2.8.1
       webpack-merge: 5.10.0
     optionalDependencies:
-      '@angular-devkit/build-angular': 21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4)
-      '@angular/build': 21.2.9(388f4330983cc9846a9970149fe71723)
+      '@angular-devkit/build-angular': 21.2.9(4cc3ab656cb840e277f06c6833a72048)
+      '@angular/build': 21.2.9(d6c73b17cf1bdc531fce60a9b6b07260)
       ng-packagr: 21.2.3(@angular/compiler-cli@21.2.9(@angular/compiler@21.2.9)(typescript@5.9.2))(tailwindcss@4.3.0)(tslib@2.8.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -20120,14 +20146,14 @@ snapshots:
       - nx
       - supports-color
 
-  '@nx/module-federation@22.7.5(7e9f33a4a4e1f118e3a7649156592283)':
+  '@nx/module-federation@22.7.5(54f57d94210f4c17056c0e5cef0ce967)':
     dependencies:
       '@module-federation/enhanced': 2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.2)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))
       '@module-federation/node': 2.7.43(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.2)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0(encoding@0.1.13))
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/web': 22.7.5(e0e07c13dc6d3bdec3871f55668cf109)
+      '@nx/web': 22.7.5(e1104a4a719209e99305d7eb66db814e)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       express: 4.21.2
       http-proxy-middleware: 3.0.5
@@ -20248,14 +20274,14 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/rspack@22.7.5(5249932e09750214990eea39f5c6f939)':
+  '@nx/rspack@22.7.5(7d47a8ddc1a47da98e3b3ca8831e3464)':
     dependencies:
       '@module-federation/enhanced': 2.5.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.2)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))
       '@module-federation/node': 2.7.43(@rspack/core@1.6.8(@swc/helpers@0.5.23))(typescript@5.9.2)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/module-federation': 22.7.5(7e9f33a4a4e1f118e3a7649156592283)
-      '@nx/web': 22.7.5(e0e07c13dc6d3bdec3871f55668cf109)
+      '@nx/module-federation': 22.7.5(54f57d94210f4c17056c0e5cef0ce967)
+      '@nx/web': 22.7.5(e1104a4a719209e99305d7eb66db814e)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.2)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       '@rspack/dev-server': 1.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15))
@@ -20319,7 +20345,7 @@ snapshots:
       - webpack-cli
       - webpack-hot-middleware
 
-  '@nx/storybook@22.7.5(23797dcc60f54bd6d406e761a6a92ef1)':
+  '@nx/storybook@22.7.5(5a6adf055d56b6f0fc47a9ff50d017ea)':
     dependencies:
       '@nx/cypress': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0)))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
@@ -20330,7 +20356,7 @@ snapshots:
       storybook: 10.4.1(@testing-library/dom@10.4.0)(@types/react@19.2.16)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/web': 22.7.5(e0e07c13dc6d3bdec3871f55668cf109)
+      '@nx/web': 22.7.5(e1104a4a719209e99305d7eb66db814e)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/jest'
@@ -20345,11 +20371,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.7.5(05420544d9d5b7a5760d8a5e0fdd0f0e)':
+  '@nx/vite@22.7.5(12086cbca555034a40c9aeb1591368f7)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vitest': 22.7.5(05420544d9d5b7a5760d8a5e0fdd0f0e)
+      '@nx/vitest': 22.7.5(12086cbca555034a40c9aeb1591368f7)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.2)
       ajv: 8.20.0
       enquirer: 2.3.6
@@ -20358,7 +20384,7 @@ snapshots:
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
       vite: 7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/eslint'
@@ -20370,7 +20396,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.7.5(05420544d9d5b7a5760d8a5e0fdd0f0e)':
+  '@nx/vitest@22.7.5(12086cbca555034a40c9aeb1591368f7)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
@@ -20380,7 +20406,7 @@ snapshots:
     optionalDependencies:
       '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0)))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       vite: 7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -20391,7 +20417,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/web@22.7.5(e0e07c13dc6d3bdec3871f55668cf109)':
+  '@nx/web@22.7.5(e1104a4a719209e99305d7eb66db814e)':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
@@ -20403,7 +20429,7 @@ snapshots:
       '@nx/cypress': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0)))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/eslint': 22.7.5(@babel/traverse@7.29.7)(@nx/jest@22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0)))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@zkochan/js-yaml@0.0.7)(eslint@10.4.1(jiti@2.4.2))(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/jest': 22.7.5(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@types/node@22.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/vite': 22.7.5(05420544d9d5b7a5760d8a5e0fdd0f0e)
+      '@nx/vite': 22.7.5(12086cbca555034a40c9aeb1591368f7)
       '@nx/webpack': 22.7.5(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(html-webpack-plugin@5.6.7(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.23))(esbuild@0.19.12)(lightningcss@1.32.0)(postcss@8.5.15)))(lightningcss@1.32.0)(nx@22.7.5(@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.9.2))(@swc/core@1.15.8(@swc/helpers@0.5.23)))(typescript@5.9.2)(verdaccio@6.7.2(encoding@0.1.13)(typanion@3.14.0))
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -22109,10 +22135,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/angular@10.4.1(11caa08e2c4605fc4c5ad8e17af988e4)':
+  '@storybook/angular@10.4.1(5ed5fa0a0020b2c75547640e46966b47)':
     dependencies:
       '@angular-devkit/architect': 0.2102.13(chokidar@5.0.0)
-      '@angular-devkit/build-angular': 21.2.9(a9efdfcb4aa098b2fc2473a04ca40ca4)
+      '@angular-devkit/build-angular': 21.2.9(4cc3ab656cb840e277f06c6833a72048)
       '@angular-devkit/core': 21.2.9(chokidar@5.0.0)
       '@angular/common': 21.2.9(@angular/core@21.2.9(@angular/compiler@21.2.9)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/compiler': 21.2.9
@@ -23120,10 +23146,72 @@ snapshots:
     dependencies:
       vite: 7.3.2(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.97.3)(terser@5.48.0)(yaml@2.9.0)
 
-  '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
+  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.60.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@vitest/browser': 4.1.8(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      playwright: 1.60.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.1.8(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.8(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.8(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/coverage-v8@4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.7
+      '@vitest/utils': 4.1.8
       ast-v8-to-istanbul: 1.0.3
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -23132,7 +23220,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@vitest/browser': 4.1.8(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -23142,26 +23232,26 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/expect@4.1.7':
+  '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.7
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.7(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.7
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -23172,19 +23262,19 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@4.1.7':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.7':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 4.1.7
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.7':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
@@ -23192,18 +23282,18 @@ snapshots:
     dependencies:
       tinyspy: 4.0.4
 
-  '@vitest/spy@4.1.7': {}
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/ui@4.1.7(vitest@4.1.7)':
+  '@vitest/ui@4.1.8(vitest@4.1.8)':
     dependencies:
-      '@vitest/utils': 4.1.7
+      '@vitest/utils': 4.1.8
       fflate: 0.8.3
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -23211,9 +23301,9 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/utils@4.1.7':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.7
+      '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -29509,6 +29599,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  pngjs@7.0.0: {}
+
   polka@0.5.2:
     dependencies:
       '@polka/url': 0.5.0
@@ -32525,15 +32617,15 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
 
-  vitest@4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@22.19.19)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -32549,21 +32641,22 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19
-      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
-      '@vitest/ui': 4.1.7(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.7(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@26.1.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(jsdom@26.1.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -32579,8 +32672,9 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
-      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
-      '@vitest/ui': 4.1.7(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      '@vitest/ui': 4.1.8(vitest@4.1.8)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,7 +229,7 @@ importers:
         specifier: 4.1.8
         version: 4.1.8(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/browser-playwright':
-        specifier: ^4.1.8
+        specifier: 4.1.8
         version: 4.1.8(playwright@1.60.0)(vite@7.1.5(@types/node@22.19.19)(jiti@2.4.2)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8':
         specifier: 4.1.8

--- a/tools/scripts/benchmark/compare.mjs
+++ b/tools/scripts/benchmark/compare.mjs
@@ -58,20 +58,11 @@ function deltaMetric(head, base) {
     return { absoluteDiff, relativeDiff, withinNoise, arrow };
 }
 
-function durationCell(headStats, baseStats) {
-    if (!baseStats) {
-        return { text: `${ms(headStats.median)} (new)`, withinNoise: false };
-    }
-    const d = deltaMetric(headStats.median, baseStats.median);
-    return {
-        text: `${ms(headStats.median)} ${signedMs(d.absoluteDiff)} (${pct(d.relativeDiff)})${d.arrow}`,
-        withinNoise: d.withinNoise
-    };
-}
-
-function paintCell(headStats, baseStats) {
+// Render one time-metric cell (duration or paint). `nullText` is shown when the head stat is absent
+// (paint can be null; duration is always present so it never hits that branch).
+function metricCell(headStats, baseStats, nullText) {
     if (!headStats) {
-        return { text: '—', withinNoise: true };
+        return { text: nullText, withinNoise: true };
     }
     if (!baseStats) {
         return { text: `${ms(headStats.median)} (new)`, withinNoise: false };
@@ -97,8 +88,8 @@ function buildRows(head, base) {
 
     const rows = head.map((h) => {
         const b = baseByName.get(h.name);
-        const duration = durationCell(h.duration, b?.duration);
-        const paint = paintCell(h.paint, b?.paint);
+        const duration = metricCell(h.duration, b?.duration, '—');
+        const paint = metricCell(h.paint, b?.paint, '—');
         const renders = rendersCell(h.renders, b?.renders);
         const significant = !duration.withinNoise || !paint.withinNoise || !renders.withinNoise;
         return { name: h.name, duration, paint, renders, significant, removed: false };
@@ -123,24 +114,37 @@ function buildRows(head, base) {
 function totalsLine(head, base) {
     const sum = (rs, pick) => rs.reduce((acc, r) => acc + (pick(r) ?? 0), 0);
     const headDur = sum(head, (r) => r.duration.median);
-    const headPaint = sum(head, (r) => r.paint?.median);
     const headRenders = sum(head, (r) => r.renders);
+    const headPaint = sum(head, (r) => r.paint?.median);
+    // Paint total is only meaningful if every head row reported a paint; otherwise drop it rather
+    // than print a sum of a partial set (or a misleading "0.0 ms" when none reported).
+    const headPaintComplete = head.every((r) => r.paint);
 
     if (!base) {
-        return `**Total duration:** ${ms(headDur)} · **Renders:** ${headRenders} · **Paint:** ${ms(headPaint)}`;
+        const paintSeg = headPaintComplete ? ` · **Paint:** ${ms(headPaint)}` : '';
+        return `**Total duration:** ${ms(headDur)} · **Renders:** ${headRenders}${paintSeg}`;
     }
     const baseDur = sum(base, (r) => r.duration.median);
-    const basePaint = sum(base, (r) => r.paint?.median);
     const baseRenders = sum(base, (r) => r.renders);
 
     const dur = deltaMetric(headDur, baseDur);
-    const paint = deltaMetric(headPaint, basePaint);
     const rDiff = headRenders - baseRenders;
+
+    let paintSeg = '';
+    // Compare paint totals only over tests that reported a paint on BOTH sides, so a missing
+    // Element Timing entry on one side can't fake a large total-paint delta.
+    const baseByName = new Map(base.map((r) => [r.name, r]));
+    const matched = head.filter((h) => h.paint && baseByName.get(h.name)?.paint);
+    if (matched.length) {
+        const headMatchedPaint = sum(matched, (r) => r.paint.median);
+        const baseMatchedPaint = sum(matched, (h) => baseByName.get(h.name).paint.median);
+        const paint = deltaMetric(headMatchedPaint, baseMatchedPaint);
+        paintSeg = ` · **Paint:** ${ms(headMatchedPaint)} ${signedMs(paint.absoluteDiff)} (${pct(paint.relativeDiff)})${paint.arrow}`;
+    }
 
     return (
         `**Total duration:** ${ms(headDur)} ${signedMs(dur.absoluteDiff)} (${pct(dur.relativeDiff)})${dur.arrow} · ` +
-        `**Renders:** ${headRenders} (${rDiff >= 0 ? '+' : ''}${rDiff}) · ` +
-        `**Paint:** ${ms(headPaint)} ${signedMs(paint.absoluteDiff)} (${pct(paint.relativeDiff)})${paint.arrow}`
+        `**Renders:** ${headRenders} (${rDiff >= 0 ? '+' : ''}${rDiff})${paintSeg}`
     );
 }
 

--- a/tools/scripts/benchmark/compare.mjs
+++ b/tools/scripts/benchmark/compare.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+// Diff two benchmark reports (head vs base) and render a PR comment + a GitHub job summary.
+//
+// Ports the comparison rules from base-ui's open-source compareBenchmarkReports.ts:
+//   - "within noise" = |relative Δ of the metric| <= NOISE_THRESHOLD (0.2 / ±20%);
+//   - a change is a regression/improvement only when it exceeds the threshold;
+//   - totals are simple sums compared with the same rule.
+// We apply the threshold to the IQR-filtered medians our harness already computes.
+//
+// Usage: node compare.mjs <head.json> <base.json> [--out <comment.md>]
+//   head.json is required. base.json may be missing/empty (bootstrap period or a build that had no
+//   perf app at the merge-base) — then we emit a "baseline unavailable" comment and exit 0.
+//   If GITHUB_STEP_SUMMARY is set, the full table is appended there too.
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+
+const NOISE_THRESHOLD = 0.2;
+const STICKY_MARKER = '<!-- radix-ng-benchmark -->';
+
+function parseArgs(argv) {
+    const positional = [];
+    let out = 'benchmark-comment.md';
+    for (let i = 0; i < argv.length; i++) {
+        if (argv[i] === '--out') {
+            out = argv[++i];
+        } else {
+            positional.push(argv[i]);
+        }
+    }
+    return { headPath: positional[0], basePath: positional[1], out };
+}
+
+function readReport(path) {
+    if (!path) {
+        return null;
+    }
+    try {
+        const parsed = JSON.parse(readFileSync(path, 'utf8'));
+        return Array.isArray(parsed) && parsed.length ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+const ms = (n) => `${n.toFixed(1)} ms`;
+const pct = (r) => `${r >= 0 ? '+' : ''}${(r * 100).toFixed(1)}%`;
+const signedMs = (n) => `${n >= 0 ? '+' : '−'}${Math.abs(n).toFixed(1)} ms`;
+
+// Lower is better for time metrics: ▼ = improvement, ▲ = regression. Arrows only when significant.
+function deltaMetric(head, base) {
+    const absoluteDiff = head - base;
+    const relativeDiff = base !== 0 ? absoluteDiff / base : 0;
+    const withinNoise = Math.abs(relativeDiff) <= NOISE_THRESHOLD;
+    let arrow = '';
+    if (!withinNoise && absoluteDiff !== 0) {
+        arrow = absoluteDiff > 0 ? ' ▲' : ' ▼';
+    }
+    return { absoluteDiff, relativeDiff, withinNoise, arrow };
+}
+
+function durationCell(headStats, baseStats) {
+    if (!baseStats) {
+        return { text: `${ms(headStats.median)} (new)`, withinNoise: false };
+    }
+    const d = deltaMetric(headStats.median, baseStats.median);
+    return {
+        text: `${ms(headStats.median)} ${signedMs(d.absoluteDiff)} (${pct(d.relativeDiff)})${d.arrow}`,
+        withinNoise: d.withinNoise
+    };
+}
+
+function paintCell(headStats, baseStats) {
+    if (!headStats) {
+        return { text: '—', withinNoise: true };
+    }
+    if (!baseStats) {
+        return { text: `${ms(headStats.median)} (new)`, withinNoise: false };
+    }
+    const d = deltaMetric(headStats.median, baseStats.median);
+    return {
+        text: `${ms(headStats.median)} ${signedMs(d.absoluteDiff)} (${pct(d.relativeDiff)})${d.arrow}`,
+        withinNoise: d.withinNoise
+    };
+}
+
+function rendersCell(head, base) {
+    if (base === undefined) {
+        return { text: `${head} (new)`, withinNoise: false };
+    }
+    const diff = head - base;
+    return { text: `${head} (${diff >= 0 ? '+' : ''}${diff})`, withinNoise: diff === 0 };
+}
+
+function buildRows(head, base) {
+    const baseByName = new Map((base ?? []).map((r) => [r.name, r]));
+    const headNames = new Set(head.map((r) => r.name));
+
+    const rows = head.map((h) => {
+        const b = baseByName.get(h.name);
+        const duration = durationCell(h.duration, b?.duration);
+        const paint = paintCell(h.paint, b?.paint);
+        const renders = rendersCell(h.renders, b?.renders);
+        const significant = !duration.withinNoise || !paint.withinNoise || !renders.withinNoise;
+        return { name: h.name, duration, paint, renders, significant, removed: false };
+    });
+
+    // Tests that existed at base but are gone at head.
+    for (const b of base ?? []) {
+        if (!headNames.has(b.name)) {
+            rows.push({
+                name: b.name,
+                duration: { text: `~~${ms(b.duration.median)}~~ (removed)`, withinNoise: false },
+                paint: { text: b.paint ? `~~${ms(b.paint.median)}~~` : '—', withinNoise: true },
+                renders: { text: `~~${b.renders}~~`, withinNoise: true },
+                significant: true,
+                removed: true
+            });
+        }
+    }
+    return rows;
+}
+
+function totalsLine(head, base) {
+    const sum = (rs, pick) => rs.reduce((acc, r) => acc + (pick(r) ?? 0), 0);
+    const headDur = sum(head, (r) => r.duration.median);
+    const headPaint = sum(head, (r) => r.paint?.median);
+    const headRenders = sum(head, (r) => r.renders);
+
+    if (!base) {
+        return `**Total duration:** ${ms(headDur)} · **Renders:** ${headRenders} · **Paint:** ${ms(headPaint)}`;
+    }
+    const baseDur = sum(base, (r) => r.duration.median);
+    const basePaint = sum(base, (r) => r.paint?.median);
+    const baseRenders = sum(base, (r) => r.renders);
+
+    const dur = deltaMetric(headDur, baseDur);
+    const paint = deltaMetric(headPaint, basePaint);
+    const rDiff = headRenders - baseRenders;
+
+    return (
+        `**Total duration:** ${ms(headDur)} ${signedMs(dur.absoluteDiff)} (${pct(dur.relativeDiff)})${dur.arrow} · ` +
+        `**Renders:** ${headRenders} (${rDiff >= 0 ? '+' : ''}${rDiff}) · ` +
+        `**Paint:** ${ms(headPaint)} ${signedMs(paint.absoluteDiff)} (${pct(paint.relativeDiff)})${paint.arrow}`
+    );
+}
+
+function table(rows) {
+    const header = '| Test | Duration | Renders | Paint |\n| --- | --- | --- | --- |';
+    const body = rows.map((r) => `| ${r.name} | ${r.duration.text} | ${r.renders.text} | ${r.paint.text} |`);
+    return [header, ...body].join('\n');
+}
+
+function render(head, base) {
+    if (!head) {
+        return `${STICKY_MARKER}\n### ⚡ Performance\n\nNo benchmark report was produced for this run.`;
+    }
+    if (!base) {
+        const rows = buildRows(head, null);
+        return [
+            STICKY_MARKER,
+            '### ⚡ Performance',
+            '',
+            '_Baseline unavailable (no benchmark report at the merge-base) — showing head numbers only._',
+            '',
+            totalsLine(head, null),
+            '',
+            table(rows)
+        ].join('\n');
+    }
+
+    const rows = buildRows(head, base);
+    const significant = rows.filter((r) => r.significant);
+    const quiet = rows.filter((r) => !r.significant);
+
+    const parts = [STICKY_MARKER, '### ⚡ Performance', '', totalsLine(head, base), ''];
+
+    if (significant.length) {
+        parts.push(table(significant));
+    } else {
+        parts.push('All benchmarks within noise (±20%). ✅');
+    }
+
+    if (quiet.length) {
+        parts.push(
+            '',
+            `<details><summary>${quiet.length} test${quiet.length === 1 ? '' : 's'} within noise</summary>`,
+            '',
+            table(quiet),
+            '',
+            '</details>'
+        );
+    }
+
+    parts.push(
+        '',
+        '<sub>Lower is better. ▲ regression · ▼ improvement · within-noise = |Δ| ≤ 20% of base median.</sub>'
+    );
+    return parts.join('\n');
+}
+
+const { headPath, basePath, out } = parseArgs(process.argv.slice(2));
+const head = readReport(headPath);
+const base = readReport(basePath);
+
+const comment = render(head, base);
+
+writeFileSync(out, `${comment}\n`);
+if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${comment}\n`);
+}
+// Also print so the logs show the table even without a PR.
+process.stdout.write(`${comment}\n`);


### PR DESCRIPTION
… comparison)

Benchmarks primitives in real Chromium (Vitest Browser Mode + Playwright) and reports mount/re-render duration, paint (Element Timing) and CD-cycle counts. Adds the apps/radix-perf-testing harness, checkbox + select pilots, the benchmark.yml workflow (same-runner head vs merge-base, sticky PR comment via compare.mjs porting base-ui's ±20% noise rule), a Guides/Performance docs page, and ADR 0009.

<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
