### PR TITLE
feat(presence): subtree-aware WAAPI exit detection (ADR 0011)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,8 +248,12 @@ For animation work, distinguish the lifecycle owner before choosing an API:
 - Always-mounted primitive parts: use CSS transitions driven by `data-state`.
 - Application-owned conditional DOM (`@if`): prefer Angular 21+ `animate.enter` / `animate.leave`;
   legacy `@angular/animations` is not required.
-- Parts mounted through `RdxPresenceDirective`: use exit CSS `@keyframes` driven by `data-state`;
-  the current presence implementation waits for `animationend`, not `transitionend`.
+- Parts mounted through `RdxPresenceDirective` / `RdxPortalPresence`: drive the exit with CSS
+  `@keyframes` (`data-closed`) **or** transitions (`data-ending-style`). Since ADR 0011 the presence
+  machine detects exits via the Web Animations API across the template root **and its subtree**, so
+  the exit may live on the positioner **or** the popup nested inside it (no positioner "decoy"
+  keyframe needed), and a duration safety-net bounds the unmount. The legacy root-`@keyframes` +
+  `animationend` path is kept only so the zoneless jsdom suites stay meaningful.
 
 ### Centralized demo styles
 
@@ -309,7 +313,7 @@ Complex components compose these headless building blocks — good entry points 
 
 - `core` — `createContext`, `useArrowNavigation`, id generators, shared types/utils.
 - `collection` — `RdxCollectionProvider` + `RdxCollectionItem`: collects item directives in **DOM order** via `contentChildren` (matches `hostDirectives` too). Read items off the instance (`item.element`, `item.value()`, `item.disabled()`); `useCollection()` = `inject(RdxCollectionProvider)`. Only consumer: `select`.
-- `portal` — `RdxPortal` (attribute): teleports its host element into a container (default `document.body`), reactively; non-element containers fall back to body. `RdxPortalPresence` (structural, `ng-template`): merges portal + presence — mounts its template while `present()` (from `RDX_PRESENCE_CONTEXT`) is true, relocates **all** root nodes into the container with **no wrapper element**, and waits for exit `@keyframes` on **every** `HTMLElement` root before unmounting (dialog backdrop + popup). This is the ADR 0010 anatomy-flattening primitive; popover is the migrated pilot (`*rdxPopoverPortal` on the positioner). Entry depends on `presence`.
+- `portal` — `RdxPortal` (attribute): teleports its host element into a container (default `document.body`), reactively; non-element containers fall back to body. `RdxPortalPresence` (structural, `ng-template`): merges portal + presence — mounts its template while `present()` (from `RDX_PRESENCE_CONTEXT`) is true, relocates **all** root nodes into the container with **no wrapper element**, and waits for exit animations before unmounting (dialog backdrop + popup). Since ADR 0011 the wait is Web-Animations-API-based and **subtree-aware**: an exit `@keyframes` **or** transition on any watched root **or any descendant** suspends the unmount (bounded by a duration safety net), so the popup's own exit keeps it mounted — no positioner "decoy" keyframe. This is the ADR 0010 anatomy-flattening primitive; popover is the migrated pilot (`*rdxPopoverPortal` on the positioner). Entry depends on `presence` and `core`.
 - `presence` — conditional mount/unmount with enter/leave animation support. The state machine lives in `presence/src/presence-machine.ts` (`PresenceMachine`, parameterized by `mountView`/`destroyView`); both `RdxPresenceDirective` (in place) and `RdxPortalPresence` (relocating) reuse it.
 - `roving-focus`, `focus-scope`, `popper` — focus roving, focus trapping, positioning.
 - `dismissable-layer` — outside-dismiss (Escape / pointer-down-outside / focus-outside). **Gotcha:** the focus-outside check is **async** (defers two microtasks before deciding), so an element that takes focus _outside_ a layer and then opens it can be dismissed a tick later. Register such elements as **branches** (`rdxDismissableLayerBranch`, or push the element into `RdxDismissableLayersContextToken.branches`) so focus/pointer on them counts as "inside" and won't dismiss. Example: a menu trigger the menubar focuses before opening a sibling popup.

--- a/apps/radix-storybook/.storybook/preview.ts
+++ b/apps/radix-storybook/.storybook/preview.ts
@@ -170,7 +170,12 @@ const preview: Preview = {
         viewport: { value: 'desktop', isRotated: false }
     },
 
-    tags: ['autodocs']
+    // `visual` opts every story into the `apps/visual-regression` per-story screenshot sweep.
+    // A story (or meta) can leave the sweep with `tags: ['!visual']` — the `!` prefix removes the
+    // tag, and Storybook only keeps it in `index.json` for stories that still carry it, which is
+    // what `stories.visual.spec.ts` filters on. (A bare `!visual` with no global `visual` would be
+    // stripped from the index and silently exclude nothing.)
+    tags: ['autodocs', 'visual']
 };
 
 export default preview;

--- a/apps/radix-storybook/.storybook/tailwind.css
+++ b/apps/radix-storybook/.storybook/tailwind.css
@@ -134,8 +134,6 @@
     --animate-popover-viewport-in: popover-viewport-in 200ms ease-out;
     --animate-popover-viewport-out: popover-viewport-out 200ms ease-in forwards;
 
-    --animate-navigation-menu-in: popover-in 150ms ease-out;
-    --animate-navigation-menu-out: popover-out 120ms ease-in;
     --animate-navigation-menu-popup-in: navigation-menu-popup-in 200ms ease;
     --animate-navigation-menu-popup-out: navigation-menu-popup-out 200ms ease;
     --animate-navigation-menu-content-in: navigation-menu-content-in 250ms ease;

--- a/apps/radix-storybook/docs/guides/animation.docs.mdx
+++ b/apps/radix-storybook/docs/guides/animation.docs.mdx
@@ -23,7 +23,7 @@ Use the lifecycle owner to choose the animation API:
 | --- | --- |
 | The element always remains mounted | CSS transition driven by `data-state` or a class |
 | Your template adds and removes the element with `@if` | Angular `animate.enter` and `animate.leave` |
-| A Radix NG presence directive mounts and unmounts the primitive part | CSS `@keyframes` driven by `data-state` |
+| A Radix NG presence directive mounts and unmounts the primitive part | CSS `@keyframes` **or** transitions driven by `data-state` / `data-ending-style` |
 | A third-party JavaScript library owns the animation | Angular animation callbacks or a controlled primitive |
 
 ## CSS transitions
@@ -67,8 +67,9 @@ its exit transition before hiding (`data-ending-style` is present while it runs)
 
 Use `@keyframes` when a primitive part is conditionally mounted through a Radix NG presence
 directive, such as `rdxCollapsiblePanelPresence`, or through a structural portal such as
-`*rdxPopoverPortal` / `*rdxTooltipPortal` (which merge portal + presence — the exit keyframes go on
-the portal's root element, e.g. the positioner).
+`*rdxPopoverPortal` / `*rdxTooltipPortal` (which merge portal + presence). The exit animation can go
+on the portal's root element (the positioner) **or any element inside it** (the popup) — see
+[Exit animations](#exit-animations-keyframes-or-transitions) below.
 
 ```html
 <ng-template rdxCollapsiblePanelPresence>
@@ -108,15 +109,26 @@ the portal's root element, e.g. the positioner).
 }
 ```
 
-`RdxPresenceDirective` checks the computed `animation-name` after the closed state is applied. If an
-exit animation is running, it keeps the element mounted until `animationend`. If no exit animation
-exists, it unmounts immediately.
+### Exit animations: keyframes or transitions
 
-Place the exit `@keyframes` on the first DOM element inside the presence template. That is the
-element whose animation lifecycle is observed.
+After the closed state is applied, the presence machine inspects the running animations
+([Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations)) on the
+template's root element **and its whole subtree**. It keeps the element mounted until every exit
+animation _started by the close_ has finished, then unmounts. If nothing animates, it unmounts
+immediately.
 
-> `RdxPresenceDirective` currently waits for CSS keyframe animations, not CSS transitions. Use
-> `@keyframes` for presence-managed exit animations.
+This means:
+
+- **Keyframes or transitions both work.** A `@keyframes` exit (`data-closed`) and a transition
+  (a property change under `data-ending-style`) are detected the same way.
+- **Any element in the template carries the exit.** With a structural portal you can put the exit on
+  the positioner (the root) or on the popup nested inside it — you do **not** need a separate
+  "decoy" keyframe on the positioner just to keep the popup mounted.
+- **Pre-existing animations are ignored.** A spinner or other animation that was already running
+  before the close does not delay the unmount; only animations that start with the close count.
+
+A duration-based safety net (the longest declared transition/animation duration plus a small buffer)
+guarantees the element still unmounts if an animation is interrupted or never reports completion.
 
 ## Angular `animate.enter` and `animate.leave`
 

--- a/apps/visual-regression/tests/presence-waapi.behavior.spec.ts
+++ b/apps/visual-regression/tests/presence-waapi.behavior.spec.ts
@@ -1,0 +1,91 @@
+import { expect, Locator, Page, test } from '@playwright/test';
+
+/**
+ * ADR 0011 — WAAPI-based exit detection for `PresenceMachine`. These need a real browser: jsdom runs
+ * no CSS, so it cannot exercise transitions, descendant keyframes, or the freshness filter. Each
+ * fixture lives in `Utilities/Presence` (tagged `!visual`) and is driven through the built Storybook.
+ *
+ * The headline cases (transition-only exit, popup-level keyframe with no positioner decoy) **fail on
+ * `main`** — there the machine watched only the root's computed `animationName` and unmounted
+ * instantly.
+ */
+async function gotoStory(page: Page, storyId: string): Promise<void> {
+    await page.goto(`/iframe.html?id=${storyId}&viewMode=story`);
+    await page.waitForSelector('#storybook-root', { state: 'attached' });
+}
+
+const mountButton = (page: Page): Locator => page.getByRole('button');
+
+test.describe('Presence WAAPI exit detection', () => {
+    test('transition-only exit keeps the content mounted until the transition finishes', async ({ page }) => {
+        await gotoStory(page, 'utilities-presence--waapi-transition-exit');
+
+        const box = page.locator('.waapi-box');
+        await mountButton(page).click();
+        await expect(box).toBeVisible();
+
+        // Close: the only exit styling is a CSS transition (no @keyframes anywhere).
+        await mountButton(page).click();
+
+        // Mid-exit: still in the DOM with the closed state applied (would be gone instantly on main).
+        await expect(box).toHaveAttribute('data-state', 'closed');
+        await expect(box).toBeAttached();
+
+        // Once the transition ends, the machine unmounts it.
+        await expect(box).toHaveCount(0);
+    });
+
+    test('keyframe exit on a descendant (no positioner decoy) keeps the content mounted', async ({ page }) => {
+        await gotoStory(page, 'utilities-presence--waapi-subtree-keyframe-exit');
+
+        const root = page.locator('.waapi-root');
+        await mountButton(page).click();
+        await expect(root).toBeVisible();
+
+        await mountButton(page).click();
+
+        // The exit @keyframes run on a child, not the watched root — subtree detection keeps it up.
+        await expect(root).toHaveAttribute('data-state', 'closed');
+        await expect(root).toBeAttached();
+
+        await expect(root).toHaveCount(0);
+    });
+
+    test('a pre-existing infinite animation does not delay the unmount (freshness filter)', async ({ page }) => {
+        await gotoStory(page, 'utilities-presence--waapi-infinite-spinner-no-delay');
+
+        const root = page.locator('.waapi-root');
+        await mountButton(page).click();
+        await expect(root).toBeVisible();
+
+        // The spinner inside has been running since mount; closing has no exit animation of its own.
+        await mountButton(page).click();
+
+        // Must unmount promptly — the infinite spinner's startTime predates the close, so it is not
+        // mistaken for an exit animation. A short timeout guards against "held open forever".
+        await expect(root).toHaveCount(0, { timeout: 1000 });
+    });
+
+    test('re-opening during a transition exit keeps the view (version guard, no teardown)', async ({ page }) => {
+        await gotoStory(page, 'utilities-presence--waapi-transition-exit');
+
+        const box = page.locator('.waapi-box');
+        await mountButton(page).click();
+        await expect(box).toBeVisible();
+
+        // Start the exit transition, then immediately re-open before it finishes.
+        await mountButton(page).click();
+        await expect(box).toHaveAttribute('data-state', 'closed');
+        await mountButton(page).click();
+
+        // The re-open bumps the exit version, so the in-flight transition's resolution is ignored and
+        // the same element stays mounted and open — no flicker/unmount.
+        await expect(box).toHaveAttribute('data-state', 'open');
+        await expect(box).toBeAttached();
+
+        // Give the stale transition time to (wrongly) resolve; it must not tear the view down.
+        await page.waitForTimeout(400);
+        await expect(box).toHaveCount(1);
+        await expect(box).toHaveAttribute('data-state', 'open');
+    });
+});

--- a/apps/visual-regression/tests/stories.visual.spec.ts
+++ b/apps/visual-regression/tests/stories.visual.spec.ts
@@ -31,7 +31,9 @@ function loadStories(): StoryEntry[] {
     const index = JSON.parse(raw) as { entries?: Record<string, StoryEntry>; stories?: Record<string, StoryEntry> };
     const entries = Object.values(index.entries ?? index.stories ?? {});
 
-    return entries.filter((entry) => entry.type === 'story' && !entry.tags?.includes('!visual'));
+    // Sweep only stories that carry the global `visual` tag (added in `.storybook/preview.ts`).
+    // A story opts out with `tags: ['!visual']`, which removes `visual` from its published tags.
+    return entries.filter((entry) => entry.type === 'story' && entry.tags?.includes('visual'));
 }
 
 const stories = loadStories();

--- a/docs/adr/0011-waapi-presence-exit-detection.md
+++ b/docs/adr/0011-waapi-presence-exit-detection.md
@@ -1,6 +1,6 @@
 # ADR 0011: WAAPI-based exit detection for presence — transitions-first styling, subtree-aware
 
-- Status: Proposed (spec for implementation; no code yet)
+- Status: Accepted — all phases landed (1 machine upgrade, 2 Playwright coverage, 3 decoy retirement + docs)
 - Date: 2026-06-13
 - Decision owners: Radix NG maintainers
 - Related: ADR 0010 (structural portal+presence; flagged this as explicit follow-up in its §4),
@@ -145,16 +145,51 @@ Once the machine is subtree-aware, the rollout's decoy convention can be unwound
 
 ## Phases (separate PRs)
 
-1. **Machine upgrade** — §1–§3 in `presence-machine.ts` (+ version guard, safety net). Existing
-   jsdom suites pass unmodified; new unit tests only for what jsdom can express (freshness
-   bookkeeping, version guard via manually-resolved fake animation objects if practical).
-2. **Playwright behavior coverage** — extend `apps/visual-regression` behavior specs:
-   - popup-only **transition** exit (no keyframes anywhere) stays mounted until `transitionend`,
-     then unmounts (this is the headline capability — fails on main today);
-   - popup-only **keyframe** exit with _no_ positioner decoy stays mounted (fails on main);
-   - infinite spinner inside an open popup does **not** delay unmount (freshness filter);
-   - re-open during a transition exit keeps the view (no flicker/teardown).
-3. **Decoy retirement + docs** — §4. Visual baselines guard the demo edits.
+1. ✅ **Machine upgrade** — §1–§3 in `presence-machine.ts` (+ version guard, safety net). DONE:
+   subtree-aware `getAnimations({ subtree: true })` with `startTime >= closeTimestamp` freshness
+   filter (snapshot via `document.timeline.currentTime` when `present` flips false), `finished`
+   promises gated by an `exitVersion` counter bumped on every mount/unmount, and a
+   `getMaxTransitionDuration`-based safety net (measured over the animated targets, falling back to
+   roots) + `EXIT_FALLBACK_BUFFER` (50 ms). The legacy root computed-`animationName` acceptor and
+   `animationstart`/`animationend` listeners are kept and gated off while a WAAPI wait owns
+   completion (`waapiPending`). `presence.directive.spec.ts` + `portal-presence.spec.ts` pass
+   unmodified; `pnpm primitives:build` green. (Used `animation.pending`, not `playState ===
+'pending'` — the latter is not in the WAAPI `playState` enum.) The version-guard / late-end path
+   is already covered by the existing "late animationend must not tear down re-opened content" jsdom
+   test; no new jsdom test added (the new paths are browser-truth → Phase 2).
+2. ✅ **Playwright behavior coverage** — DONE. `apps/visual-regression/tests/presence-waapi.behavior.spec.ts`
+   (4 tests, green) driven by three `!visual` fixtures under `Utilities/Presence`
+   (`presence-waapi-{transition,subtree,spinner}.ts`), each exercising `RdxPresenceDirective`'s
+   shared `PresenceMachine`:
+   - **transition** exit on the root (no keyframes anywhere) stays mounted until the transition
+     finishes, then unmounts — the headline capability;
+   - **keyframe** exit on a _descendant_ (no root/positioner decoy) stays mounted — proves
+     `{ subtree: true }`;
+   - **infinite spinner** running since mount does **not** delay unmount — proves the freshness
+     filter;
+   - **re-open during the transition exit** keeps the same element mounted+open — proves the
+     version guard.
+     Verified as genuine regression guards: with the Phase-1 machine reverted (old root-only event
+     path), the transition / subtree / re-open tests **fail** and only the spinner test (trivially)
+     passes. Infra fix bundled: the `!visual` opt-out was a no-op (Storybook strips `!`-prefixed tags
+     from `index.json`); added a global `visual` tag in `.storybook/preview.ts` and flipped
+     `stories.visual.spec.ts` to include-by-`visual`, which also repairs `menu-safe-polygon`'s
+     previously-ineffective opt-out. No new screenshot baselines (fixtures are behavior-only).
+3. ✅ **Decoy retirement + docs** — DONE. Removed the positioner opacity "decoy" from
+   `demoPopover`/`demoNavigationMenu` (styles.ts) and their story usages (`popover-animated`, the 8
+   navigation-menu stories, `recipes/notification-dropdown`); those popups already carry their own
+   opacity+transform exit (`popover-popup-out` via `data-state`; `navigation-menu-popup-out` via
+   `data-ending-style`), so the subtree machine keeps them mounted. Dropped the now-unused
+   `--animate-navigation-menu-in/out` CSS vars (kept `popover-in/out` — still used by the
+   `build-a-styled-component` learn tutorials, where the positioner opacity is the _sole_ animation,
+   not a decoy). **Menu kept its positioner carrier** (`menu-animated`): the shared `demoMenu.popup`
+   has `data-[closed]:hidden` (reused by always-rendered menubar popups), so on close the menu popup
+   is `display:none` and cannot run its own exit — verified in-browser (positioner unmounts
+   synchronously without the carrier). Per §4 that is "a visual choice", not a removable decoy.
+   Updated `animation.docs.mdx` (new "Exit animations: keyframes or transitions" section) + CLAUDE.md
+   (presence lifecycle row + portal bullet) + regenerated the skills bundle. Verified: popover /
+   navigation-menu / menu / presence-waapi behavior specs (12) green, overlays.visual unchanged (no
+   static drift).
 
 ## Testing
 

--- a/packages/primitives/menu/stories/menu-animated.ts
+++ b/packages/primitives/menu/stories/menu-animated.ts
@@ -34,8 +34,13 @@ import { cn, demoButton, demoMenu } from '../../storybook/styles';
             .animated-popup[data-ending-style] {
                 animation: popup-out 150ms ease;
             }
-            /* The structural *rdxMenuPortal watches its root (the positioner); give it an opacity exit
-               keyframe so presence keeps the popup mounted until the popup's slide-out finishes. */
+            /*
+             * Unlike popover/navigation-menu, the shared menu popup carries 'data-[closed]:hidden' (it
+             * is reused by the always-rendered menubar popups), so on close it is 'display: none' and
+             * cannot run its own exit animation. The exit therefore lives on the positioner — keyed on
+             * its 'data-open'/'data-closed' — which is what the presence machine waits on before
+             * unmounting. This is a legitimate carrier, not an ADR-0011 "decoy".
+             */
             @keyframes positioner-fade-in {
                 from {
                     opacity: 0;

--- a/packages/primitives/navigation-menu/stories/navigation-menu-custom-links.ts
+++ b/packages/primitives/navigation-menu/stories/navigation-menu-custom-links.ts
@@ -91,12 +91,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>

--- a/packages/primitives/navigation-menu/stories/navigation-menu-default.ts
+++ b/packages/primitives/navigation-menu/stories/navigation-menu-default.ts
@@ -58,12 +58,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <svg
                         [class]="m.arrow"

--- a/packages/primitives/navigation-menu/stories/navigation-menu-large.ts
+++ b/packages/primitives/navigation-menu/stories/navigation-menu-large.ts
@@ -37,12 +37,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>

--- a/packages/primitives/navigation-menu/stories/navigation-menu-nested-inline.ts
+++ b/packages/primitives/navigation-menu/stories/navigation-menu-nested-inline.ts
@@ -69,12 +69,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>

--- a/packages/primitives/navigation-menu/stories/navigation-menu-nested.ts
+++ b/packages/primitives/navigation-menu/stories/navigation-menu-nested.ts
@@ -49,7 +49,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
 
                                 <div
                                     *rdxNavigationMenuPortal
-                                    [class]="cn(m.positioner, m.positionerAnimated)"
+                                    [class]="m.positioner"
                                     side="right"
                                     sideOffset="12"
                                     align="start"
@@ -69,12 +69,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>

--- a/packages/primitives/navigation-menu/stories/navigation-menu-rtl.ts
+++ b/packages/primitives/navigation-menu/stories/navigation-menu-rtl.ts
@@ -33,12 +33,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 }
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>

--- a/packages/primitives/navigation-menu/stories/navigation-menu-vertical.ts
+++ b/packages/primitives/navigation-menu/stories/navigation-menu-vertical.ts
@@ -35,7 +35,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
 
             <div
                 *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
+                [class]="m.positioner"
                 side="right"
                 sideOffset="8"
                 align="start"

--- a/packages/primitives/popover/stories/popover-animated.ts
+++ b/packages/primitives/popover/stories/popover-animated.ts
@@ -10,7 +10,7 @@ import { cn, demoButton, demoPopover } from '../../storybook/styles';
         <ng-container rdxPopoverRoot>
             <button [class]="cn(b.base, b.outline, b.size.md)" rdxPopoverTrigger>Animated popover</button>
 
-            <div *rdxPopoverPortal [class]="cn(p.positioner, p.positionerAnimated)" sideOffset="8" rdxPopoverPositioner>
+            <div *rdxPopoverPortal [class]="p.positioner" sideOffset="8" rdxPopoverPositioner>
                 <div [class]="cn(p.popup, p.popupAnimated)" rdxPopoverPopup>
                     <span [class]="p.arrow" rdxPopoverArrow></span>
                     <h2 [class]="p.title" rdxPopoverTitle>Native CSS keyframes</h2>

--- a/packages/primitives/presence/src/presence-machine.ts
+++ b/packages/primitives/presence/src/presence-machine.ts
@@ -1,4 +1,5 @@
 import { afterNextRender, effect, Injector, Signal } from '@angular/core';
+import { getMaxTransitionDuration } from '@radix-ng/primitives/core';
 
 type PresenceState = 'mounted' | 'unmountSuspended' | 'unmounted';
 type PresenceEvent = 'MOUNT' | 'UNMOUNT' | 'ANIMATION_OUT' | 'ANIMATION_END';
@@ -16,6 +17,14 @@ const MACHINE: Record<PresenceState, Partial<Record<PresenceEvent, PresenceState
     unmountSuspended: { MOUNT: 'mounted', ANIMATION_END: 'unmounted' },
     unmounted: { MOUNT: 'mounted' }
 };
+
+/**
+ * Grace period (ms) added to the longest declared exit duration before the safety-net timer
+ * force-completes the exit. Only matters when a `finished` promise never settles (the engine
+ * under-reports `getAnimations`, the animation is replaced without a cancel, reduced motion, …).
+ * Mirrors `TRANSITION_FALLBACK_BUFFER` in `use-transition-status.ts`.
+ */
+const EXIT_FALLBACK_BUFFER = 50;
 
 /**
  * Operations the host directive supplies to {@link PresenceMachine}. The machine owns *when* the
@@ -42,10 +51,19 @@ export interface PresenceMachineHost {
 
 /**
  * Reusable presence state machine extracted from `RdxPresenceDirective`. It keeps content mounted
- * while a CSS exit animation (`@keyframes` applied for the closed state) is running on *any* watched
- * root node, and unmounts only once every running exit animation has finished. With no exit
- * animation it unmounts immediately. For a single watched node this reduces exactly to the original
- * `RdxPresenceDirective` behavior.
+ * while a CSS exit animation runs anywhere inside the template — a `@keyframes` **or** a
+ * `transition` (`data-ending-style`), on a watched root **or any of its descendants** — and unmounts
+ * only once every exit animation started by the close has finished. With no exit animation it
+ * unmounts immediately. For a single watched node and a root-level keyframe this reduces exactly to
+ * the original `RdxPresenceDirective` behavior.
+ *
+ * Detection (ADR 0011) uses the Web Animations API: when `present()` flips `false` we snapshot a
+ * close timestamp, and after the next render collect `node.getAnimations({ subtree: true })`, keeping
+ * only animations that are running/pending and were *started by* the close (`startTime` null or
+ * `>= closeTimestamp`). The view stays mounted until all of their `finished` promises settle, bounded
+ * by a duration-based safety net. The legacy root-level computed-`animationName` check and the
+ * `animationstart`/`animationend` listeners are kept as an additional acceptor — they drive the
+ * zoneless jsdom suites (where `getAnimations` is absent) and cost nothing in a real browser.
  */
 export class PresenceMachine {
     private state: PresenceState;
@@ -53,11 +71,26 @@ export class PresenceMachine {
 
     /** Root nodes currently watched for exit animations (set on mount). */
     private nodes: HTMLElement[] = [];
-    /** Last-seen computed `animationName` per node, used to detect a *fresh* exit animation. */
+    /** Last-seen computed `animationName` per node, used to detect a *fresh* root exit animation. */
     private readonly prevAnimationNames = new WeakMap<HTMLElement, string>();
-    /** Nodes whose exit animation we are still waiting on before unmounting. */
+    /** Root nodes whose exit animation the event path is still waiting on (jsdom / root-keyframe). */
     private readonly pendingExits = new Set<HTMLElement>();
     private removeListeners: (() => void) | null = null;
+
+    /**
+     * Timeline time captured the moment `present` flipped `false`, on the same clock as
+     * `Animation.startTime`. Animations started at or after it are the exit animations.
+     */
+    private closeTimestamp = 0;
+    /**
+     * Monotonic counter bumped on every mount/unmount transition. A suspended exit captures it and
+     * its `finished`/safety-net resolution is ignored if it changed in the meantime (re-open or a
+     * second close), so a stale promise can never tear down a freshly-reopened view.
+     */
+    private exitVersion = 0;
+    /** True while a WAAPI `finished`-promise wait owns completion; gates the event path off. */
+    private waapiPending = false;
+    private safetyTimer: ReturnType<typeof setTimeout> | null = null;
 
     constructor(private readonly host: PresenceMachineHost) {
         this.prevPresent = host.present();
@@ -80,9 +113,12 @@ export class PresenceMachine {
                     // Mount synchronously so the enter animation can start on this frame.
                     this.send('MOUNT');
                 } else if (host.isBrowser) {
+                    // Snapshot the close time *now* (before the render that applies the closed-state
+                    // styles) so the freshness filter can tell exit animations from pre-existing ones.
+                    this.closeTimestamp = this.now();
                     // Defer the unmount decision until the next render, so the consumer's
-                    // `data-state` (and therefore the exit `@keyframes`) is applied to the DOM
-                    // before we read the computed animation name.
+                    // `data-state` / `data-ending-style` (and therefore the exit styles) are applied
+                    // to the DOM before we read the running animations.
                     afterNextRender(() => this.evaluateExit(), { injector: host.injector });
                 } else {
                     this.send('UNMOUNT');
@@ -106,13 +142,14 @@ export class PresenceMachine {
 
         this.pendingExits.clear();
 
+        // Legacy acceptor: a watched root whose closed state starts a *different* `@keyframes`.
+        // This is what the zoneless jsdom suite drives (via synthetic `animationstart`/`animationend`)
+        // and what catches root keyframes in engines that do not expose `getAnimations`.
         for (const node of this.nodes) {
             const styles = getComputedStyle(node);
             const currentAnimationName = styles.animationName || 'none';
             const prevAnimationName = this.prevAnimationNames.get(node) ?? 'none';
 
-            // Only suspend for a node whose closed state actually starts a *different* animation
-            // (and that is not hidden).
             const isAnimating =
                 currentAnimationName !== 'none' &&
                 styles.display !== 'none' &&
@@ -123,9 +160,103 @@ export class PresenceMachine {
             }
         }
 
-        // No root runs a fresh exit animation — unmount right away. Otherwise suspend until every
-        // pending exit animation has finished.
-        this.send(this.pendingExits.size === 0 ? 'UNMOUNT' : 'ANIMATION_OUT');
+        // WAAPI acceptor (ADR 0011): subtree-aware, transitions *or* keyframes, on any element in the
+        // template. This is what makes popup-level exits work without a positioner decoy keyframe.
+        const exitAnimations = this.collectExitAnimations();
+
+        if (this.pendingExits.size === 0 && exitAnimations.length === 0) {
+            // Nothing runs a fresh exit animation — unmount right away.
+            this.send('UNMOUNT');
+            return;
+        }
+
+        this.send('ANIMATION_OUT');
+
+        if (exitAnimations.length > 0) {
+            // WAAPI sees the whole subtree, so it supersedes the root-event path for this close:
+            // wait for every fresh exit animation, version-guarded against re-open.
+            this.waapiPending = true;
+            const version = this.exitVersion;
+
+            void Promise.all(exitAnimations.map((animation) => animation.finished.catch(() => undefined))).then(() =>
+                this.finishExit(version)
+            );
+
+            this.armSafetyNet(version, exitAnimations);
+        }
+        // else: no WAAPI animations (jsdom, or an engine without `getAnimations`) → the root-event
+        // path drains `pendingExits` through `onEnd`, exactly as before this ADR.
+    }
+
+    /**
+     * Running/pending animations across the watched subtrees that were *started by* the close.
+     * Pre-existing animations (an infinite spinner, a settled enter) have an earlier `startTime`
+     * and must not delay the unmount.
+     */
+    private collectExitAnimations(): Animation[] {
+        if (!this.host.isBrowser) {
+            return [];
+        }
+
+        const result: Animation[] = [];
+
+        for (const node of this.nodes) {
+            if (typeof node.getAnimations !== 'function') {
+                continue;
+            }
+
+            for (const animation of node.getAnimations({ subtree: true })) {
+                const fresh = animation.startTime === null || Number(animation.startTime) >= this.closeTimestamp;
+
+                // `animation.pending` is the WAAPI "created but not yet started this frame" flag — a
+                // freshly triggered exit. `playState` itself never reports `'pending'`.
+                if ((animation.playState === 'running' || animation.pending) && fresh) {
+                    result.push(animation);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Force-completes the exit shortly after the longest declared duration, in case a `finished`
+     * promise never settles. Measures the animated targets (falling back to the roots).
+     */
+    private armSafetyNet(version: number, exitAnimations: Animation[]): void {
+        const targets = new Set<HTMLElement>(this.nodes);
+
+        for (const animation of exitAnimations) {
+            const target = (animation.effect as KeyframeEffect | null)?.target;
+            if (target instanceof HTMLElement) {
+                targets.add(target);
+            }
+        }
+
+        let maxDuration = 0;
+        for (const element of targets) {
+            maxDuration = Math.max(maxDuration, getMaxTransitionDuration(element));
+        }
+
+        this.clearSafetyNet();
+        this.safetyTimer = setTimeout(() => this.finishExit(version), maxDuration + EXIT_FALLBACK_BUFFER);
+    }
+
+    /** Settle a WAAPI/safety-net exit wait, ignoring it if a newer mount/unmount superseded it. */
+    private finishExit(version: number): void {
+        if (version !== this.exitVersion) {
+            return;
+        }
+        this.waapiPending = false;
+        this.clearSafetyNet();
+        this.send('ANIMATION_END');
+    }
+
+    private clearSafetyNet(): void {
+        if (this.safetyTimer !== null) {
+            clearTimeout(this.safetyTimer);
+            this.safetyTimer = null;
+        }
     }
 
     private send(event: PresenceEvent): void {
@@ -137,6 +268,11 @@ export class PresenceMachine {
         this.state = next;
 
         if (next === 'mounted') {
+            // Bump the version so any in-flight exit wait from a prior close is ignored.
+            this.exitVersion++;
+            this.waapiPending = false;
+            this.clearSafetyNet();
+
             if (this.nodes.length > 0) {
                 // Re-opened while an exit animation was running — refresh the tracked animations and
                 // drop any pending exits so a late `animationend` cannot tear down the live view.
@@ -148,6 +284,7 @@ export class PresenceMachine {
                 this.mount();
             }
         } else if (next === 'unmounted') {
+            this.exitVersion++;
             this.unmount();
         }
         // `unmountSuspended` keeps the existing view mounted until ANIMATION_END.
@@ -167,6 +304,8 @@ export class PresenceMachine {
     private unmount(): void {
         this.removeListeners?.();
         this.removeListeners = null;
+        this.clearSafetyNet();
+        this.waapiPending = false;
         this.host.destroyView();
         this.nodes = [];
         this.pendingExits.clear();
@@ -190,8 +329,10 @@ export class PresenceMachine {
             }
 
             this.pendingExits.delete(node);
-            if (this.pendingExits.size === 0) {
-                this.send('ANIMATION_END');
+            // While a WAAPI wait owns completion it is authoritative (it sees the full subtree); the
+            // event path only drives the unmount when no WAAPI animations were detected.
+            if (!this.waapiPending && this.pendingExits.size === 0) {
+                this.finishExit(this.exitVersion);
             }
         };
 
@@ -212,5 +353,11 @@ export class PresenceMachine {
 
     private getAnimationName(node: HTMLElement): string {
         return (this.host.isBrowser ? getComputedStyle(node).animationName : '') || 'none';
+    }
+
+    /** Current timeline time on the same clock as `Animation.startTime` (ms), or 0 if unavailable. */
+    private now(): number {
+        const time = typeof document !== 'undefined' ? document.timeline?.currentTime : null;
+        return typeof time === 'number' ? time : Number(time ?? 0);
     }
 }

--- a/packages/primitives/presence/stories/presence-waapi-spinner.ts
+++ b/packages/primitives/presence/stories/presence-waapi-spinner.ts
@@ -1,0 +1,55 @@
+import { Component, inject, signal } from '@angular/core';
+import { provideRdxPresenceContext } from '@radix-ng/primitives/presence';
+import { PresenceDemo } from './presence';
+
+/**
+ * ADR 0011 fixture for the **freshness filter**: a never-ending spinner runs inside the content the
+ * whole time it is open, but there is no exit animation. The spinner's `startTime` predates the
+ * close, so `startTime >= closeTimestamp` excludes it and the content unmounts immediately — a
+ * subtree-aware machine must not be held open forever by a pre-existing infinite animation. Driven
+ * by `presence-waapi.behavior.spec.ts`.
+ */
+@Component({
+    selector: 'presence-waapi-spinner',
+    imports: [PresenceDemo],
+    providers: [provideRdxPresenceContext(() => ({ present: inject(PresenceWaapiSpinner).open }))],
+    styles: `
+        @keyframes waapi-spin {
+            to {
+                transform: rotate(360deg);
+            }
+        }
+
+        /* Pre-existing infinite animation — running before *and* during the close, never an exit. */
+        .waapi-spinner {
+            animation: waapi-spin 1s linear infinite;
+        }
+    `,
+    template: `
+        <div class="flex flex-col items-center gap-4">
+            <button
+                class="border-border bg-background text-foreground hover:bg-muted focus-visible:ring-ring inline-flex h-9 items-center rounded-md border px-4 text-sm font-medium shadow-sm outline-none focus-visible:ring-2"
+                (click)="open.set(!open())"
+                type="button"
+            >
+                {{ open() ? 'Unmount' : 'Mount' }}
+            </button>
+
+            <div class="flex h-28 items-center">
+                <ng-template presenceDemo>
+                    <div
+                        class="waapi-root border-border bg-card flex h-24 w-48 items-center justify-center rounded-md border shadow-sm"
+                        [attr.data-state]="open() ? 'open' : 'closed'"
+                    >
+                        <div
+                            class="waapi-spinner border-muted-foreground size-6 rounded-full border-2 border-t-transparent"
+                        ></div>
+                    </div>
+                </ng-template>
+            </div>
+        </div>
+    `
+})
+export class PresenceWaapiSpinner {
+    readonly open = signal(false);
+}

--- a/packages/primitives/presence/stories/presence-waapi-subtree.ts
+++ b/packages/primitives/presence/stories/presence-waapi-subtree.ts
@@ -1,0 +1,56 @@
+import { Component, inject, signal } from '@angular/core';
+import { provideRdxPresenceContext } from '@radix-ng/primitives/presence';
+import { PresenceDemo } from './presence';
+
+/**
+ * ADR 0011 fixture: the exit `@keyframes` run on a **nested child**, not the watched root. The root
+ * itself has no animation. Before the WAAPI upgrade only the root was inspected, so this unmounted
+ * instantly (this is exactly what the rollout's positioner "decoy keyframes" worked around); with
+ * `getAnimations({ subtree: true })` the descendant exit keeps the element mounted. Driven by
+ * `presence-waapi.behavior.spec.ts`.
+ */
+@Component({
+    selector: 'presence-waapi-subtree',
+    imports: [PresenceDemo],
+    providers: [provideRdxPresenceContext(() => ({ present: inject(PresenceWaapiSubtree).open }))],
+    styles: `
+        @keyframes waapi-child-exit {
+            from {
+                opacity: 1;
+            }
+            to {
+                opacity: 0;
+            }
+        }
+
+        /* The exit animation lives on a descendant; the root carries no animation/transition. */
+        .waapi-root[data-state='closed'] .waapi-child {
+            animation: waapi-child-exit 300ms ease-in;
+        }
+    `,
+    template: `
+        <div class="flex flex-col items-center gap-4">
+            <button
+                class="border-border bg-background text-foreground hover:bg-muted focus-visible:ring-ring inline-flex h-9 items-center rounded-md border px-4 text-sm font-medium shadow-sm outline-none focus-visible:ring-2"
+                (click)="open.set(!open())"
+                type="button"
+            >
+                {{ open() ? 'Unmount' : 'Mount' }}
+            </button>
+
+            <div class="flex h-28 items-center">
+                <ng-template presenceDemo>
+                    <div
+                        class="waapi-root border-border bg-card flex h-24 w-48 items-center justify-center rounded-md border p-2 shadow-sm"
+                        [attr.data-state]="open() ? 'open' : 'closed'"
+                    >
+                        <div class="waapi-child text-card-foreground text-sm">subtree exit</div>
+                    </div>
+                </ng-template>
+            </div>
+        </div>
+    `
+})
+export class PresenceWaapiSubtree {
+    readonly open = signal(false);
+}

--- a/packages/primitives/presence/stories/presence-waapi-transition.ts
+++ b/packages/primitives/presence/stories/presence-waapi-transition.ts
@@ -1,0 +1,53 @@
+import { Component, inject, signal } from '@angular/core';
+import { provideRdxPresenceContext } from '@radix-ng/primitives/presence';
+import { PresenceDemo } from './presence';
+
+/**
+ * ADR 0011 fixture: the exit is a **CSS transition** (no `@keyframes` anywhere). Before the WAAPI
+ * upgrade the presence machine only watched the root's computed `animationName`, so a transition
+ * unmounted instantly; now `getAnimations()` sees the running transition and keeps the element
+ * mounted until it finishes. Driven by `presence-waapi.behavior.spec.ts`.
+ */
+@Component({
+    selector: 'presence-waapi-transition',
+    imports: [PresenceDemo],
+    providers: [provideRdxPresenceContext(() => ({ present: inject(PresenceWaapiTransition).open }))],
+    styles: `
+        .waapi-box {
+            transition:
+                opacity 300ms ease,
+                transform 300ms ease;
+        }
+
+        /* Exit is a transition — the machine must wait for it via the Web Animations API. */
+        .waapi-box[data-state='closed'] {
+            opacity: 0;
+            transform: scale(0.96);
+        }
+    `,
+    template: `
+        <div class="flex flex-col items-center gap-4">
+            <button
+                class="border-border bg-background text-foreground hover:bg-muted focus-visible:ring-ring inline-flex h-9 items-center rounded-md border px-4 text-sm font-medium shadow-sm outline-none focus-visible:ring-2"
+                (click)="open.set(!open())"
+                type="button"
+            >
+                {{ open() ? 'Unmount' : 'Mount' }}
+            </button>
+
+            <div class="flex h-28 items-center">
+                <ng-template presenceDemo>
+                    <div
+                        class="waapi-box border-border bg-card text-card-foreground flex h-24 w-48 items-center justify-center rounded-md border text-sm shadow-sm"
+                        [attr.data-state]="open() ? 'open' : 'closed'"
+                    >
+                        transition exit
+                    </div>
+                </ng-template>
+            </div>
+        </div>
+    `
+})
+export class PresenceWaapiTransition {
+    readonly open = signal(false);
+}

--- a/packages/primitives/presence/stories/presence.stories.ts
+++ b/packages/primitives/presence/stories/presence.stories.ts
@@ -1,12 +1,20 @@
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { tailwindDemoDecorator } from '../../storybook/tailwind-demo';
 import { PresenceExample } from './presence';
+import { PresenceWaapiSpinner } from './presence-waapi-spinner';
+import spinnerSource from './presence-waapi-spinner?raw';
+import { PresenceWaapiSubtree } from './presence-waapi-subtree';
+import subtreeSource from './presence-waapi-subtree?raw';
+import { PresenceWaapiTransition } from './presence-waapi-transition';
+import transitionSource from './presence-waapi-transition?raw';
+
+const source = (code: string) => ({ docs: { source: { code, language: 'typescript' } } });
 
 export default {
     title: 'Utilities/Presence',
     decorators: [
         moduleMetadata({
-            imports: [PresenceExample]
+            imports: [PresenceExample, PresenceWaapiTransition, PresenceWaapiSubtree, PresenceWaapiSpinner]
         }),
         tailwindDemoDecorator()
     ]
@@ -17,5 +25,36 @@ type Story = StoryObj;
 export const Default: Story = {
     render: () => ({
         template: `<presence-example />`
+    })
+};
+
+/**
+ * ADR 0011 behavior fixtures — exercised by
+ * `apps/visual-regression/tests/presence-waapi.behavior.spec.ts` in a real browser (jsdom runs no
+ * CSS). Tagged `!visual` so they are skipped by the per-story screenshot sweep; their value is the
+ * interaction, not a static frame.
+ */
+
+export const WaapiTransitionExit: Story = {
+    tags: ['!visual'],
+    parameters: source(transitionSource),
+    render: () => ({
+        template: `<presence-waapi-transition />`
+    })
+};
+
+export const WaapiSubtreeKeyframeExit: Story = {
+    tags: ['!visual'],
+    parameters: source(subtreeSource),
+    render: () => ({
+        template: `<presence-waapi-subtree />`
+    })
+};
+
+export const WaapiInfiniteSpinnerNoDelay: Story = {
+    tags: ['!visual'],
+    parameters: source(spinnerSource),
+    render: () => ({
+        template: `<presence-waapi-spinner />`
     })
 };

--- a/packages/primitives/recipes/notification-dropdown.ts
+++ b/packages/primitives/recipes/notification-dropdown.ts
@@ -55,13 +55,7 @@ interface Notification {
                 }
             </button>
 
-            <div
-                *rdxPopoverPortal
-                [class]="cn(p.positioner, p.positionerAnimated)"
-                sideOffset="8"
-                align="end"
-                rdxPopoverPositioner
-            >
+            <div *rdxPopoverPortal [class]="p.positioner" sideOffset="8" align="end" rdxPopoverPositioner>
                 <div [class]="popup" rdxPopoverPopup>
                     <div class="border-border flex items-center justify-between border-b px-4 py-3">
                         <h2 [class]="p.title" rdxPopoverTitle>Notifications</h2>

--- a/packages/primitives/storybook/styles.ts
+++ b/packages/primitives/storybook/styles.ts
@@ -297,15 +297,13 @@ export const demoToast = {
 /**
  * Popover surfaces and parts.
  *
- * `positionerAnimated` goes on the `rdxPopoverPositioner` element: since the structural
- * `*rdxPopoverPortal` made the positioner the presence root, its exit keyframes are what the presence
- * machine waits for before unmounting. It keys on the positioner's `data-open`/`data-closed`
- * attributes and animates opacity only (no transform), so it never fights the popper's positioning.
- * `popupAnimated` drives the popup's own zoom/slide via `data-state`.
+ * `popupAnimated` drives the popup's own zoom/slide via `data-state`; that exit animation is what the
+ * presence machine waits for before unmounting (ADR 0011 — `getAnimations({ subtree: true })` sees
+ * the popup even though the positioner is the structural `*rdxPopoverPortal` root). No positioner-level
+ * "decoy" opacity keyframe is needed; the transparent positioner carries no exit animation of its own.
  */
 export const demoPopover = {
     positioner: 'z-50',
-    positionerAnimated: 'data-[open]:animate-popover-in data-[closed]:animate-popover-out',
     popup: cn(demoCard, 'relative w-80 p-4'),
     popupAnimated: 'data-[state=open]:animate-popover-popup-in data-[state=closed]:animate-popover-popup-out',
     backdrop: 'fixed inset-0 bg-foreground/10',
@@ -434,10 +432,8 @@ export const demoNavigationMenu = {
     ),
     icon: 'size-3.5 transition-transform duration-200 data-[state=open]:rotate-180',
     positioner: 'z-50 data-[closed]:pointer-events-none',
-    // Goes on the `rdxNavigationMenuPositioner` (the structural `*rdxNavigationMenuPortal` root) and
-    // keys on its `data-open`/`data-closed` attributes. Opacity-only, so it never fights the popper's
-    // positioning transform; the popup's own zoom is driven by the transition-status flow.
-    positionerAnimated: 'data-[open]:animate-navigation-menu-in data-[closed]:animate-navigation-menu-out',
+    // The popup's own `data-ending-style` zoom (below) is the exit the presence machine waits for
+    // (ADR 0011 — subtree-aware), so the positioner needs no opacity "decoy" keyframe.
     popup: cn(
         demoCard,
         'relative overflow-hidden p-0 origin-[var(--transform-origin)]',

--- a/skills/radix-ng-examples/references/components/menu.md
+++ b/skills/radix-ng-examples/references/components/menu.md
@@ -619,8 +619,13 @@ import { cn, demoButton, demoMenu } from '../../storybook/styles';
             .animated-popup[data-ending-style] {
                 animation: popup-out 150ms ease;
             }
-            /* The structural *rdxMenuPortal watches its root (the positioner); give it an opacity exit
-               keyframe so presence keeps the popup mounted until the popup's slide-out finishes. */
+            /*
+             * Unlike popover/navigation-menu, the shared menu popup carries 'data-[closed]:hidden' (it
+             * is reused by the always-rendered menubar popups), so on close it is 'display: none' and
+             * cannot run its own exit animation. The exit therefore lives on the positioner — keyed on
+             * its 'data-open'/'data-closed' — which is what the presence machine waits on before
+             * unmounting. This is a legitimate carrier, not an ADR-0011 "decoy".
+             */
             @keyframes positioner-fade-in {
                 from {
                     opacity: 0;

--- a/skills/radix-ng-examples/references/components/navigation-menu.md
+++ b/skills/radix-ng-examples/references/components/navigation-menu.md
@@ -67,12 +67,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <svg
                         [class]="m.arrow"
@@ -258,12 +253,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <svg
                         [class]="m.arrow"
@@ -342,7 +332,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
 
             <div
                 *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
+                [class]="m.positioner"
                 side="right"
                 sideOffset="8"
                 align="start"
@@ -408,12 +398,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 }
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>
@@ -568,12 +553,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>
@@ -644,12 +624,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>
@@ -738,7 +713,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
 
                                 <div
                                     *rdxNavigationMenuPortal
-                                    [class]="cn(m.positioner, m.positionerAnimated)"
+                                    [class]="m.positioner"
                                     side="right"
                                     sideOffset="12"
                                     align="start"
@@ -758,12 +733,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>
@@ -860,12 +830,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>

--- a/skills/radix-ng-examples/references/components/popover.md
+++ b/skills/radix-ng-examples/references/components/popover.md
@@ -416,7 +416,7 @@ import { cn, demoButton, demoPopover } from '../../storybook/styles';
         <ng-container rdxPopoverRoot>
             <button [class]="cn(b.base, b.outline, b.size.md)" rdxPopoverTrigger>Animated popover</button>
 
-            <div *rdxPopoverPortal [class]="cn(p.positioner, p.positionerAnimated)" sideOffset="8" rdxPopoverPositioner>
+            <div *rdxPopoverPortal [class]="p.positioner" sideOffset="8" rdxPopoverPositioner>
                 <div [class]="cn(p.popup, p.popupAnimated)" rdxPopoverPopup>
                     <span [class]="p.arrow" rdxPopoverArrow></span>
                     <h2 [class]="p.title" rdxPopoverTitle>Native CSS keyframes</h2>

--- a/skills/radix-ng-examples/references/llms-full.txt
+++ b/skills/radix-ng-examples/references/llms-full.txt
@@ -11219,8 +11219,13 @@ import { cn, demoButton, demoMenu } from '../../storybook/styles';
             .animated-popup[data-ending-style] {
                 animation: popup-out 150ms ease;
             }
-            /* The structural *rdxMenuPortal watches its root (the positioner); give it an opacity exit
-               keyframe so presence keeps the popup mounted until the popup's slide-out finishes. */
+            /*
+             * Unlike popover/navigation-menu, the shared menu popup carries 'data-[closed]:hidden' (it
+             * is reused by the always-rendered menubar popups), so on close it is 'display: none' and
+             * cannot run its own exit animation. The exit therefore lives on the positioner — keyed on
+             * its 'data-open'/'data-closed' — which is what the presence machine waits on before
+             * unmounting. This is a legitimate carrier, not an ADR-0011 "decoy".
+             */
             @keyframes positioner-fade-in {
                 from {
                     opacity: 0;
@@ -12240,12 +12245,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <svg
                         [class]="m.arrow"
@@ -12431,12 +12431,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <svg
                         [class]="m.arrow"
@@ -12515,7 +12510,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
 
             <div
                 *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
+                [class]="m.positioner"
                 side="right"
                 sideOffset="8"
                 align="start"
@@ -12581,12 +12576,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 }
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>
@@ -12741,12 +12731,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>
@@ -12817,12 +12802,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>
@@ -12911,7 +12891,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
 
                                 <div
                                     *rdxNavigationMenuPortal
-                                    [class]="cn(m.positioner, m.positionerAnimated)"
+                                    [class]="m.positioner"
                                     side="right"
                                     sideOffset="12"
                                     align="start"
@@ -12931,12 +12911,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>
@@ -13033,12 +13008,7 @@ import { cn, demoNavigationMenu } from '../../storybook/styles';
                 </li>
             </ul>
 
-            <div
-                *rdxNavigationMenuPortal
-                [class]="cn(m.positioner, m.positionerAnimated)"
-                sideOffset="8"
-                rdxNavigationMenuPositioner
-            >
+            <div *rdxNavigationMenuPortal [class]="m.positioner" sideOffset="8" rdxNavigationMenuPositioner>
                 <div [class]="m.popup" rdxNavigationMenuPopup>
                     <div [class]="m.viewport" rdxNavigationMenuViewport></div>
                 </div>
@@ -14331,7 +14301,7 @@ import { cn, demoButton, demoPopover } from '../../storybook/styles';
         <ng-container rdxPopoverRoot>
             <button [class]="cn(b.base, b.outline, b.size.md)" rdxPopoverTrigger>Animated popover</button>
 
-            <div *rdxPopoverPortal [class]="cn(p.positioner, p.positionerAnimated)" sideOffset="8" rdxPopoverPositioner>
+            <div *rdxPopoverPortal [class]="p.positioner" sideOffset="8" rdxPopoverPositioner>
                 <div [class]="cn(p.popup, p.popupAnimated)" rdxPopoverPopup>
                     <span [class]="p.arrow" rdxPopoverArrow></span>
                     <h2 [class]="p.title" rdxPopoverTitle>Native CSS keyframes</h2>
@@ -21379,13 +21349,7 @@ interface Notification {
                 }
             </button>
 
-            <div
-                *rdxPopoverPortal
-                [class]="cn(p.positioner, p.positionerAnimated)"
-                sideOffset="8"
-                align="end"
-                rdxPopoverPositioner
-            >
+            <div *rdxPopoverPortal [class]="p.positioner" sideOffset="8" align="end" rdxPopoverPositioner>
                 <div [class]="popup" rdxPopoverPopup>
                     <div class="border-border flex items-center justify-between border-b px-4 py-3">
                         <h2 [class]="p.title" rdxPopoverTitle>Notifications</h2>
@@ -21586,13 +21550,7 @@ interface Notification {
                 }
             </button>
 
-            <div
-                *rdxPopoverPortal
-                [class]="cn(p.positioner, p.positionerAnimated)"
-                sideOffset="8"
-                align="end"
-                rdxPopoverPositioner
-            >
+            <div *rdxPopoverPortal [class]="p.positioner" sideOffset="8" align="end" rdxPopoverPositioner>
                 <div [class]="popup" rdxPopoverPopup>
                     <div class="border-border flex items-center justify-between border-b px-4 py-3">
                         <h2 [class]="p.title" rdxPopoverTitle>Notifications</h2>

--- a/skills/radix-ng-examples/references/recipes/notification-dropdown.md
+++ b/skills/radix-ng-examples/references/recipes/notification-dropdown.md
@@ -65,13 +65,7 @@ interface Notification {
                 }
             </button>
 
-            <div
-                *rdxPopoverPortal
-                [class]="cn(p.positioner, p.positionerAnimated)"
-                sideOffset="8"
-                align="end"
-                rdxPopoverPositioner
-            >
+            <div *rdxPopoverPortal [class]="p.positioner" sideOffset="8" align="end" rdxPopoverPositioner>
                 <div [class]="popup" rdxPopoverPopup>
                     <div class="border-border flex items-center justify-between border-b px-4 py-3">
                         <h2 [class]="p.title" rdxPopoverTitle>Notifications</h2>
@@ -272,13 +266,7 @@ interface Notification {
                 }
             </button>
 
-            <div
-                *rdxPopoverPortal
-                [class]="cn(p.positioner, p.positionerAnimated)"
-                sideOffset="8"
-                align="end"
-                rdxPopoverPositioner
-            >
+            <div *rdxPopoverPortal [class]="p.positioner" sideOffset="8" align="end" rdxPopoverPositioner>
                 <div [class]="popup" rdxPopoverPopup>
                     <div class="border-border flex items-center justify-between border-b px-4 py-3">
                         <h2 [class]="p.title" rdxPopoverTitle>Notifications</h2>


### PR DESCRIPTION
Upgrade PresenceMachine to detect exit animations via the Web Animations API across the template root and its whole subtree, so an exit can be a @keyframes OR a CSS transition, on the positioner OR the popup nested inside it — retiring the positioner "decoy keyframe" convention.

<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- ✅ Add or edit tests to reflect the change
- 🔍 Add or edit Storybook examples to reflect the change.
- 🙏 Please review your own PR to check for anything you may have missed.

-->

### Description

<!-- Describe the change you are introducing -->
